### PR TITLE
fix(sync): allow hard deletes for table_transient_data

### DIFF
--- a/oosync.codegen.config.json
+++ b/oosync.codegen.config.json
@@ -45,6 +45,9 @@
     "config": {
       "push": {
         "tableRules": {
+          "table_transient_data": {
+            "denyDelete": false
+          },
           "practice_record": {
             "denyDelete": true,
             "upsert": {

--- a/src/lib/db/client-sqlite.ts
+++ b/src/lib/db/client-sqlite.ts
@@ -151,7 +151,7 @@ const DB_KEY_PREFIX = "tunetrees-db";
 const DB_VERSION_KEY_PREFIX = "tunetrees-db-version";
 const OUTBOX_BACKUP_KEY_PREFIX = "tunetrees-outbox-backup";
 // Current serialized database schema version. Increment to force recreation after schema-affecting changes.
-const CURRENT_DB_VERSION = 8; // v8: Fix tag table schema (tag_id column) and trigger compatibility
+const CURRENT_DB_VERSION = 9; // v9: Remove denyDelete rule for table_transient_data to allow hard deletes
 
 // Sync watermark key prefix used by SyncEngine (duplicated here to avoid import cycles)
 const LAST_SYNC_TIMESTAMP_KEY_PREFIX = "TT_LAST_SYNC_TIMESTAMP";

--- a/worker/src/generated/worker-config.generated.ts
+++ b/worker/src/generated/worker-config.generated.ts
@@ -394,7 +394,7 @@ export const WORKER_SYNC_CONFIG =
         }
       },
       "table_transient_data": {
-        "denyDelete": true,
+        "denyDelete": false,
         "sanitize": {
           "coerceNumericProps": [
             {


### PR DESCRIPTION
fix(sync): allow hard deletes for table_transient_data

- Add explicit denyDelete: false override in oosync.codegen.config.json
- Regenerate worker config with correct denyDelete setting
- Increment CURRENT_DB_VERSION to 9 to clear stale DELETE operations

The worker was refusing thousands of legitimate DELETE operations for
table_transient_data because codegen auto-adds denyDelete: true for
tables without soft-delete flags. This table uses hard deletes by
design as it's a transient staging area for the practice UI.

Fixes slow load times and worker log spam from refused DELETEs.