### PR TITLE
Provision worker JWT secret during deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,12 +768,9 @@ jobs:
         uses: 1password/install-cli-action@v2
 
       - name: Deploy Worker
-        # `op run` resolves CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID,
-        # SUPABASE_JWT_SECRET, etc. from .env.prod.template without storing
-        # them as separate GitHub secrets.
-        run: |
-          op run --env-file="../.env.prod.template" -- \
-            npx wrangler deploy
+        # The worker JWT secret must exist as a Cloudflare Worker secret binding.
+        # Loading it into the deploy shell via `op run` is not enough by itself.
+        run: npm run deploy
         working-directory: worker
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/worker/package.json
+++ b/worker/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "deploy": "FORCE_COLOR=1 op run --env-file=\"../.env.prod.template\" -- wrangler deploy",
+    "deploy": "FORCE_COLOR=1 op run --env-file=\"../.env.prod.template\" -- sh -c 'printf \"%s\" \"$SUPABASE_JWT_SECRET\" | npx wrangler secret put SUPABASE_JWT_SECRET && npx wrangler deploy'",
     "dev": "FORCE_COLOR=1 op run --env-file=\"../.env.local.template\" -- node ./scripts/run-wrangler-dev.mjs",
     "dev:local": "WRANGLER_SEND_METRICS=false DO_NOT_TRACK=1 FORCE_COLOR=1 op run --env-file=\"../.env.local.template\" -- node ./scripts/run-wrangler-dev.mjs --local",
     "start": "FORCE_COLOR=1 op run --env-file=\"../.env.local.template\" -- node ./scripts/run-wrangler-dev.mjs"


### PR DESCRIPTION
## Summary
Provision `SUPABASE_JWT_SECRET` as a real Cloudflare Worker secret before deploying the sync worker.

## Changes
- update `worker/package.json` so `npm run deploy` uploads `SUPABASE_JWT_SECRET` via `wrangler secret put` before `wrangler deploy`
- update the GitHub Actions worker deploy job to call the worker deploy script instead of invoking `wrangler deploy` directly

## Why
The previous deploy path loaded `SUPABASE_JWT_SECRET` into the local deploy shell via `op run`, but that did not create a runtime secret binding in Cloudflare. In production this left the worker unable to verify Supabase JWTs, causing `/api/sync` to return `401 Unauthorized`.

## Validation
- editor diagnostics clean for the touched files
- isolated branch diff contains only `.github/workflows/ci.yml` and `worker/package.json`
