### PR TITLE
Fix npm ci on Vite 8 installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,6 @@ iti_import_output
 
 # Local/personal config files
 .gitconfig
-.npmrc
 
 # Database files (local development)
 *.sqlite3

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# vite-plugin-pwa@1.2.0 still advertises a Vite <=7 peer range.
+# TuneTrees installs and builds on Vite 8, so keep npm from failing on stale peer metadata.
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- track a root `.npmrc` with `legacy-peer-deps=true`
- stop ignoring `.npmrc` in `.gitignore`
- keep local and CI `npm ci` behavior aligned while staying on `vite@8.0.3`

## Why
`vite-plugin-pwa@1.2.0` still advertises a Vite peer range capped at 7, so plain `npm ci` fails with `ERESOLVE` on Vite 8 unless legacy peer deps is enabled. CI already had that override via environment variables; this change makes local installs behave the same way without downgrading Vite.

## Validation
- `npm ci` succeeds locally with the tracked root `.npmrc`
