### PR TITLE
First pass design-system UI refactor

### DIFF
--- a/design/tunetrees-design-system.md
+++ b/design/tunetrees-design-system.md
@@ -1,0 +1,97 @@
+# TuneTrees UI Design System & Style Guide
+
+This document serves as the single source of truth for the TuneTrees UI grammar, action vocabulary, and visual hierarchy. It ensures a consistent, predictable, and professional user experience across the entire application.
+
+---
+
+## 🛠️ 1. Core Dependencies
+
+* **Icon Library:** All icons MUST be from `lucide-solid` **version 1.14.0 or greater**.
+* **CSS Framework:** Tailwind CSS, utilizing a semantic token-based architecture (e.g., `bg-primary`, `text-muted-foreground`). Do not use hardcoded colors (e.g., `blue-500`) for structural UI elements.
+
+---
+
+## 🎨 2. Color Semantics (The Vocabulary)
+
+*Rule: Colors must mean the same thing everywhere. Never use a semantic color for mere decoration.*
+
+| Semantic Token | Visual Representation | Meaning & Use Case |
+| :--- | :--- | :--- |
+| **Primary** | Solid Bright Blue (`bg-primary`) | **Forward Progress.** Used ONLY for the primary conversion or completion action on a screen (e.g., "Sign In", "Submit Practice", "Save Tune"). |
+| **Secondary / Muted** | Slate Gray (`bg-secondary`, `text-muted-foreground`) | **Neutral / Context.** Used for secondary actions, background panels, inactive tabs, and supporting text (like timestamps or UUIDs). |
+| **Accent** | Green / Purple | **Success / Specialty.** Green is strictly for "Good/Easy" or successful states. Purple should be used sparingly, perhaps for premium/special features or profiles. |
+| **Warning** | Orange / Yellow | **Attention Required.** Used for "Overdue" status, "Again/Hard" practice evaluations, and actions that require a system change (like "Rebuild Queue"). |
+| **Destructive** | Red (`bg-destructive`) | **Permanent Loss.** Used strictly for deleting data (e.g., "Delete Tune", "Remove Override"). |
+
+---
+
+## 🎛️ 3. Button Hierarchy (The Verbs)
+
+*Rule: A screen should almost never have more than ONE Primary button. If everything is loud, nothing is.*
+
+| Button Variant | CSS Implementation | Strict Use Case |
+| :--- | :--- | :--- |
+| **1. Primary Action** | `variant="default"` (Solid Blue) | The single most important action on the screen. **Rule:** Place on the bottom-right of desktop forms, or full-width at the bottom of mobile forms. |
+| **2. Secondary Action** | `variant="outline"` (Border, no fill) | Safe, alternative actions. E.g., "Cancel", "Add More", "Filter". **Rule:** Place to the left of Primary actions. |
+| **3. Tertiary Action** | `variant="ghost"` (No border, gray hover) | Navigation, icon-only utility buttons (like the `⋮` menu), or very low-priority actions. |
+| **4. The FSRS Array** | *Custom App-Specific Pattern* | The "Again/Hard/Good/Easy" buttons are a special case. They should remain visually distinct from standard app navigation to keep the user in a "flow state" during practice. |
+
+---
+
+## 📐 4. Layout & Forms (The Grammar)
+
+*Rule: Predictability reduces cognitive load. Users shouldn't have to relearn how to use a form on a new page.*
+
+| Component | UI Grammar Rule |
+| :--- | :--- |
+| **Form Headers** | Desktop: Split pattern. Title in center, `[Cancel]` on far left, `[Save]` on far right. (Or Title left, Actions right). |
+| **Mobile Toolbars** | Maximize vertical space. Limit top toolbars to 1 Tab Dropdown, 1 Primary Action, and 1 `⋮` Overflow menu. |
+| **Empty States** | Never show a blank screen. Always include a muted Icon, a brief explanation, and an `outline` button directing the user to add data. |
+| **Toggles vs. Checkboxes** | Use a **Toggle Switch** (pill shape) for immediate state changes (e.g., "Flashcard Mode On/Off"). Use **Checkboxes** (squares) for batch selections or form data that requires a "Save" button to take effect. |
+
+---
+
+## 📖 5. The Action Dictionary (Standardizing the Verbs)
+
+This index dictates exactly how common actions are handled across TuneTrees.
+
+| Intent / Action | UI Text Label | Button Variant | Standard Icon (`lucide-solid`) | Strict Placement Rule |
+| :--- | :--- | :--- | :--- | :--- |
+| **Commit Data** | "Save" or "Submit" | `Primary` | `Save` (💾) | Far right of action group. Final step in a flow. |
+| **Create New Entity** | "Add [Item]" | `Primary` or `Outline`* | `Plus` (➕) | Top right of lists, or bottom of empty states. *(Primary if main action, Outline if secondary).* |
+| **Revert / Escape** | "Cancel" | `Outline` or `Ghost` | None (Usually text-only) | Far left of action group, or top-left of a modal. |
+| **Dismiss View** | None (Icon only) | `Ghost` | `X` (✖️) | Top right corner of dialogs, modals, and slide-overs. |
+| **Navigate Back** | "Back" | `Ghost` | `ChevronLeft` (<) | Top left of a screen (especially on mobile). |
+| **Modify Data** | "Edit" | `Outline` or `Ghost` | `SquarePen` (📝) | Next to the entity title, or inside a `⋮` menu. *(Note: Do NOT use standard `Pencil` as this implies full form/record edits).* |
+| **Permanently Erase** | "Delete" | `Destructive` | `Trash2` (🗑️) | Inside an overflow menu, or far left/bottom of an edit form. **Always requires a confirmation dialog.** |
+| **Remove Relation** | "Remove" | `Outline` or `Ghost` | `Minus` or `X` | Use when taking a tune out of a playlist (the tune still exists in the DB). |
+| **View Details** | "Info" or "Details" | `Ghost` | `Info` (ℹ️) | Next to complex terms or inside list rows. |
+| **Options/Overflow**| None (Icon only) | `Ghost` | `MoreVertical` (⋮) | Far right of a row, card, or mobile toolbar. |
+
+---
+
+## 🔣 6. Iconography & Text Rules (The Syntax)
+
+Icons are powerful, but they can create massive cognitive load if used inconsistently.
+
+**Rule 1: Icon + Text (The Standard for Primary Actions)**
+* **When to use:** For your most important, screen-anchoring actions (e.g., `[ 💾 Save ]`, `[ ➕ Add Tune ]`).
+* **The Order:** The icon **ALWAYS** goes on the left of the text (e.g., `[Icon] Text`).
+    * *Exception:* Directional indicators (like a dropdown caret or a "Next Page" arrow) go on the right: `[ Text ▾ ]` or `[ Next ➔ ]`.
+
+**Rule 2: Text Only (The Standard for Secondary Actions)**
+* **When to use:** For standard form actions where an icon adds clutter rather than clarity.
+* **Examples:** "Cancel", "Submit", "Sign In". If adding an icon doesn't immediately make the button faster to understand, leave it out. Clean typography is often better than a forced icon.
+
+**Rule 3: Icon Only (The High-Risk, High-Reward Pattern)**
+* **When to use:** **ONLY** when the icon is a universally understood convention AND space is extremely tight (like a mobile toolbar or a dense data row).
+* **Approved "Icon Only" concepts:**
+    * Search (`Search`)
+    * Close/Dismiss (`X`)
+    * Filter (`Filter`)
+    * Settings (`Settings`)
+    * Overflow Menu (`MoreVertical`)
+* **The Accessibility Mandate:** Every single "Icon Only" button MUST have an `aria-label` in the code and a standard `Tooltip` component that appears on desktop hover.
+
+**Rule 4: Icon Consistency (The "Weight" Rule)**
+* Ensure the `stroke-width` is exactly the same across the entire app (default for Lucide is usually `2px`). Do not mix thick, filled icons with thin, delicate line icons.

--- a/e2e/helpers/practice-view.ts
+++ b/e2e/helpers/practice-view.ts
@@ -209,13 +209,29 @@ export async function submitAndWaitForPracticeSettled(
 ): Promise<void> {
   await ttPage.submitEvaluations({ timeoutMs });
   await page.waitForLoadState("networkidle", { timeout: timeoutMs });
-  await expect(ttPage.submitEvaluationsButton).toBeDisabled({
-    timeout: timeoutMs,
-  });
-  await expect(ttPage.submitEvaluationsButton).toHaveAttribute(
-    "title",
-    /Submit 0 practice evaluations/i,
-    { timeout: timeoutMs }
-  );
+
+  await expect
+    .poll(
+      async () => {
+        const [disabled, title] = await Promise.all([
+          ttPage.submitEvaluationsButton.isDisabled().catch(() => false),
+          ttPage.submitEvaluationsButton.getAttribute("title"),
+        ]);
+
+        return {
+          disabled,
+          title: title ?? "",
+        };
+      },
+      {
+        timeout: timeoutMs,
+        intervals: [100, 250, 500, 1000],
+      }
+    )
+    .toEqual({
+      disabled: true,
+      title: expect.stringMatching(/Submit 0 practice evaluations/i),
+    });
+
   await waitForPracticeViewSettled(page, ttPage, { timeoutMs });
 }

--- a/e2e/page-objects/TuneTreesPage.ts
+++ b/e2e/page-objects/TuneTreesPage.ts
@@ -2523,10 +2523,7 @@ export class TuneTreesPage {
   }
 
   private getColumnVisibilityMenu(): Locator {
-    return this.page
-      .locator("div.fixed.w-64:visible")
-      .filter({ hasText: /Show All|Hide All/i })
-      .last();
+    return this.page.getByTestId("column-visibility-menu").last();
   }
 
   private getDisplayOptionsButton(): Locator {

--- a/e2e/page-objects/TuneTreesPage.ts
+++ b/e2e/page-objects/TuneTreesPage.ts
@@ -2532,6 +2532,38 @@ export class TuneTreesPage {
       .last();
   }
 
+  private async waitForColumnVisibilityMenu(
+    targetMenu: Locator = this.getColumnVisibilityMenu(),
+    timeout = 5000
+  ): Promise<boolean> {
+    return expect
+      .poll(
+        async () => {
+          const menuVisible = await targetMenu
+            .isVisible({ timeout: 200 })
+            .catch(() => false);
+          if (menuVisible) {
+            return true;
+          }
+
+          const menuCount = await this.page
+            .getByTestId("column-visibility-menu")
+            .count()
+            .catch(() => 0);
+          return menuCount > 0
+            ? await targetMenu.isVisible({ timeout: 200 }).catch(() => false)
+            : false;
+        },
+        {
+          timeout,
+          intervals: [100, 250, 500],
+        }
+      )
+      .toBe(true)
+      .then(() => true)
+      .catch(() => false);
+  }
+
   private async openColumnVisibilityMenu(
     columnsButton: Locator,
     targetMenu: Locator = this.getColumnVisibilityMenu()
@@ -2557,6 +2589,14 @@ export class TuneTreesPage {
     if (this.page.isClosed()) {
       return;
     }
+
+    const menuOpened = await this.waitForColumnVisibilityMenu(targetMenu);
+    if (menuOpened) {
+      return;
+    }
+
+    await columnsButton.click().catch(() => undefined);
+    await this.openDisplayOptionsEntryIfNeeded(columnsButton, targetMenu);
     await expect(targetMenu).toBeVisible({ timeout: 5000 });
   }
 
@@ -2626,8 +2666,22 @@ export class TuneTreesPage {
         return;
       }
 
+      const displayOptionsVisible = await displayOptionsButton
+        .isVisible({ timeout: 250 })
+        .catch(() => false);
+      if (!displayOptionsVisible) {
+        await this.openOverflowMenuEntry(columnsButton, displayOptionsButton);
+      }
       await this.openOverflowMenuEntry(columnsButton, displayOptionsButton);
-      await this.page.waitForTimeout(OVERFLOW_MENU_RETRY_DELAY_MS);
+      await displayOptionsButton.click().catch(() => undefined);
+
+      const menuOpened = await this.waitForColumnVisibilityMenu(
+        targetMenu,
+        OVERFLOW_MENU_RETRY_DELAY_MS + 1500
+      );
+      if (menuOpened) {
+        return;
+      }
     }
 
     if (this.page.isClosed()) {

--- a/e2e/tests/scheduling-003-repeated-easy.spec.ts
+++ b/e2e/tests/scheduling-003-repeated-easy.spec.ts
@@ -10,7 +10,10 @@ import {
   DEFAULT_DETERMINISTIC_FSRS_TEST_CONFIG,
 } from "../helpers/fsrs-test-config";
 import { setupForPracticeTestsParallel } from "../helpers/practice-scenarios";
-import { waitForPracticeViewSettled } from "../helpers/practice-view";
+import {
+  runTestHook,
+  waitForPracticeViewSettled,
+} from "../helpers/practice-view";
 import {
   queryLatestPracticeRecord,
   queryPracticeRecords,
@@ -330,7 +333,7 @@ test.describe("SCHEDULING-003: Repeated Easy Evaluations", () => {
         });
 
         // After reload, ensure we pull any data that was flushed server-side
-        await page.evaluate(() => (window as any).__forceSyncDownForTest?.());
+        await runTestHook(page, "__forceSyncDownForTest");
         await page.waitForLoadState("networkidle", { timeout: 15000 });
         await diagAuth(page, `day-${day}-after-syncdown`);
         await ttPage.refreshDateRolloverIfVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jodit": "^4.9.6",
         "jose": "^6.1.3",
         "loglevel": "^1.9.2",
-        "lucide-solid": "^0.575.0",
+        "lucide-solid": "^1.14.0",
         "oosync": "git+https://github.com/sboagy/oosync.git#main",
         "papaparse": "^5.5.3",
         "quickjs-emscripten": "^0.32.0",
@@ -1958,7 +1958,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9794,9 +9794,9 @@
       }
     },
     "node_modules/lucide-solid": {
-      "version": "0.575.0",
-      "resolved": "https://registry.npmjs.org/lucide-solid/-/lucide-solid-0.575.0.tgz",
-      "integrity": "sha512-EGdV4Kql+N/SpEJnLlgeUpTQPtarUJ8DpRWc8LpiymVCqcb2QffKMwrrG1ECY2omP+gVTZOu/5mJ3WmIj93kDg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-solid/-/lucide-solid-1.14.0.tgz",
+      "integrity": "sha512-OeuC91agcJS3CyneSo96VpdkUAQdQO8c8r0QO5/FIkGnlfJ7Gd0fw3Z6CcdKnG94P0Ydwt+He2ar3oeTzbuNnw==",
       "license": "ISC",
       "peerDependencies": {
         "solid-js": "^1.4.7"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "jodit": "^4.9.6",
     "jose": "^6.1.3",
     "loglevel": "^1.9.2",
-    "lucide-solid": "^0.575.0",
+    "lucide-solid": "^1.14.0",
     "oosync": "git+https://github.com/sboagy/oosync.git#main",
     "papaparse": "^5.5.3",
     "quickjs-emscripten": "^0.32.0",

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -598,24 +598,6 @@ export const LoginForm: Component<LoginFormProps> = (props) => {
             disabled={isSubmitting() || loading()}
             class="w-full flex items-center justify-center gap-3 py-2 [@media(max-height:760px)]:py-1.5 px-4 bg-white hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <svg class="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                fill="currentColor"
-                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-              />
-              <path
-                fill="currentColor"
-                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-              />
-              <path
-                fill="currentColor"
-                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-              />
-              <path
-                fill="currentColor"
-                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-              />
-            </svg>
             <span>Continue with Google</span>
           </button>
 
@@ -626,14 +608,6 @@ export const LoginForm: Component<LoginFormProps> = (props) => {
             disabled={isSubmitting() || loading()}
             class="w-full flex items-center justify-center gap-3 py-2 [@media(max-height:760px)]:py-1.5 px-4 bg-gray-900 hover:bg-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 text-white font-medium rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <svg
-              class="w-5 h-5"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-            </svg>
             <span>Continue with GitHub</span>
           </button>
         </div>

--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -7,6 +7,7 @@
  * @module components/auth/LogoutButton
  */
 
+import { Loader2, LogOut } from "lucide-solid";
 import { type Component, createSignal, Show } from "solid-js";
 import { useAuth } from "../../lib/auth/AuthContext";
 
@@ -70,45 +71,13 @@ export const LogoutButton: Component<LogoutButtonProps> = (props) => {
           when={!isLoggingOut() && !loading()}
           fallback={
             <span class="flex items-center gap-2">
-              <svg
-                class="animate-spin h-4 w-4"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle
-                  class="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  stroke-width="4"
-                  fill="none"
-                />
-                <path
-                  class="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
+              <Loader2 class="animate-spin h-4 w-4" aria-hidden="true" />
               <Show when={!props.iconOnly}>Signing out...</Show>
             </span>
           }
         >
           <Show when={props.iconOnly} fallback={<span>Sign Out</span>}>
-            <svg
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-              />
-            </svg>
+            <LogOut class="w-5 h-5" aria-hidden="true" />
           </Show>
         </Show>
       </button>

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Navigate } from "@solidjs/router";
+import { Loader2 } from "lucide-solid";
 import { type ParentComponent, Show } from "solid-js";
 import { useAuth } from "../../lib/auth/AuthContext";
 
@@ -44,26 +45,10 @@ export const ProtectedRoute: ParentComponent<ProtectedRouteProps> = (props) => {
       fallback={
         <div class="flex items-center justify-center min-h-screen">
           <div class="text-center">
-            <svg
+            <Loader2
               class="animate-spin h-12 w-12 mx-auto text-blue-600"
-              viewBox="0 0 24 24"
               aria-hidden="true"
-            >
-              <circle
-                class="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-                fill="none"
-              />
-              <path
-                class="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
+            />
             <p class="mt-4 text-gray-600 dark:text-gray-400">Loading...</p>
           </div>
         </div>

--- a/src/components/catalog/CatalogControlBanner.tsx
+++ b/src/components/catalog/CatalogControlBanner.tsx
@@ -19,6 +19,7 @@
 
 import { useLocation, useNavigate } from "@solidjs/router";
 import type { Table } from "@tanstack/solid-table";
+import { ChevronDown, Columns, Plus, Search, Trash2 } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createEffect, createSignal } from "solid-js";
 import { useAuth } from "../../lib/auth/AuthContext";
@@ -186,20 +187,7 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
             title="Add selected tunes to repertoire"
             class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_NEUTRAL}`}
           >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-              />
-            </svg>
+            <Plus class="w-4 h-4" aria-hidden="true" />
             <span class="hidden lg:inline">Add To Repertoire</span>
             <span class="lg:hidden hidden sm:inline">Add To Rep</span>
           </button>
@@ -215,20 +203,10 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
               class="w-full px-4 py-2 pl-10 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 min-w-[12ch]"
               style="min-width: 12ch"
             />
-            <svg
+            <Search
               class="absolute left-3 top-2.5 w-4 h-4 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
               aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
+            />
           </div>
 
           {/* Combined filter dropdown */}
@@ -254,20 +232,7 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
             title="Add a new tune"
             class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_SUCCESS}`}
           >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
+            <Plus class="w-4 h-4" aria-hidden="true" />
             <span class="hidden lg:inline">Add Tune</span>
             <span class="lg:hidden">Add</span>
           </button>
@@ -280,20 +245,7 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
             disabled={!props.selectedRowsCount || props.selectedRowsCount === 0}
             class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_DANGER}`}
           >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1-1H9a1 1 0 00-1 1v3M4 7h16"
-              />
-            </svg>
+            <Trash2 class="w-4 h-4" aria-hidden="true" />
             <span class="hidden lg:inline">Delete Tunes</span>
             <span class="lg:hidden">Delete</span>
           </button>
@@ -310,35 +262,9 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
             title="Show/hide columns"
             class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_NEUTRAL}`}
           >
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"
-              />
-            </svg>
+            <Columns class="w-4 h-4" aria-hidden="true" />
             <span class="hidden lg:inline">Columns</span>
-            <svg
-              class="w-4 h-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
+            <ChevronDown class="w-4 h-4" aria-hidden="true" />
           </button>
 
           {/* Columns dropdown menu */}

--- a/src/components/catalog/CatalogToolbar.tsx
+++ b/src/components/catalog/CatalogToolbar.tsx
@@ -19,7 +19,15 @@
 
 import { DropdownMenu } from "@kobalte/core/dropdown-menu";
 import type { Table } from "@tanstack/solid-table";
-import { ChevronRight, Columns, EllipsisVertical, Plus } from "lucide-solid";
+import {
+  ChevronDown,
+  ChevronRight,
+  Columns,
+  EllipsisVertical,
+  Plus,
+  Search,
+  Trash2,
+} from "lucide-solid";
 import type { Component } from "solid-js";
 import { createEffect, createSignal, Show } from "solid-js";
 import { createIsMobile } from "@/lib/hooks/useIsMobile";
@@ -225,20 +233,7 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
     return (
       <div class="flex min-w-0 flex-1 items-center gap-2">
         <div class="relative min-w-0 flex-1">
-          <svg
-            class={TOOLBAR_SEARCH_ICON}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
-          </svg>
+          <Search class={TOOLBAR_SEARCH_ICON} aria-hidden="true" />
           <input
             type="text"
             placeholder="Search tunes..."
@@ -362,39 +357,13 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
                 class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_PRIMARY}`}
                 disabled={!canAddToRepertoire()}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-                  />
-                </svg>
+                <Plus class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Add To Repertoire</span>
               </button>
 
               {/* Search input - always visible across all screen sizes */}
               <div class={TOOLBAR_SEARCH_CONTAINER}>
-                <svg
-                  class={TOOLBAR_SEARCH_ICON}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                  />
-                </svg>
+                <Search class={TOOLBAR_SEARCH_ICON} aria-hidden="true" />
                 <input
                   type="text"
                   placeholder="Search tunes..."
@@ -433,20 +402,7 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
                 data-testid="catalog-add-tune-button"
                 class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_SUCCESS}`}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M12 4v16m8-8H4"
-                  />
-                </svg>
+                <Plus class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Add Tune</span>
               </button>
 
@@ -461,20 +417,7 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
                 }
                 class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_DANGER}`}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1-1H9a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
+                <Trash2 class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Delete</span>
               </button>
             </div>
@@ -495,20 +438,7 @@ export const CatalogToolbar: Component<CatalogToolbarProps> = (props) => {
                 >
                   <Columns size={14} />
                   <span>Display Options</span>
-                  <svg
-                    class="w-3.5 h-3.5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
+                  <ChevronDown class="w-3.5 h-3.5" aria-hidden="true" />
                 </button>
               </div>
             </div>

--- a/src/components/catalog/ColumnVisibilityMenu.tsx
+++ b/src/components/catalog/ColumnVisibilityMenu.tsx
@@ -288,6 +288,7 @@ export const ColumnVisibilityMenu: Component<ColumnVisibilityMenuProps> = (
       <Portal>
         <div
           ref={menuRef}
+          data-testid="column-visibility-menu"
           class="fixed w-64 bg-white dark:bg-gray-800 border border-gray-200/30 dark:border-gray-700/30 rounded-md shadow-lg z-[100] overflow-y-auto"
           style={{
             ...dropdownStyle(),

--- a/src/components/catalog/CombinedFilterDropdown.tsx
+++ b/src/components/catalog/CombinedFilterDropdown.tsx
@@ -8,6 +8,7 @@
  * @module components/catalog/CombinedFilterDropdown
  */
 
+import { ChevronDown } from "lucide-solid";
 import { type Component, createSignal, For, onCleanup, Show } from "solid-js";
 import type { RepertoireWithSummary } from "../../lib/db/queries/repertoires";
 
@@ -128,21 +129,10 @@ export const CombinedFilterDropdown: Component<CombinedFilterDropdownProps> = (
             {totalSelected()}
           </span>
         </Show>
-        {/* Upside-down caret */}
-        <svg
+        <ChevronDown
           class={`w-4 h-4 transition-transform ${isOpen() ? "rotate-180" : ""}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <title>Toggle filters dropdown</title>
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+          aria-hidden="true"
+        />
       </button>
 
       {/* Dropdown panel */}

--- a/src/components/catalog/CompactFilterDropdown.tsx
+++ b/src/components/catalog/CompactFilterDropdown.tsx
@@ -8,6 +8,7 @@
  * @module components/catalog/CompactFilterDropdown
  */
 
+import { ChevronDown } from "lucide-solid";
 import {
   type Component,
   createSignal,
@@ -91,20 +92,10 @@ export const CompactFilterDropdown: Component<CompactFilterDropdownProps> = (
         class="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors min-w-[140px] justify-between"
       >
         <span class="truncate">{displayText()}</span>
-        <svg
+        <ChevronDown
           class={`w-4 h-4 transition-transform ${isOpen() ? "rotate-180" : ""}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <title>Dropdown arrow</title>
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+          aria-hidden="true"
+        />
       </button>
 
       {/* Dropdown menu */}

--- a/src/components/catalog/FilterPanel.tsx
+++ b/src/components/catalog/FilterPanel.tsx
@@ -10,6 +10,7 @@
  * @module components/catalog/FilterPanel
  */
 
+import { ChevronDown, Filter, X } from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -77,14 +78,7 @@ const FilterChip: Component<{
         class="hover:bg-opacity-20 hover:bg-gray-600 rounded-full p-0.5 transition-colors"
         aria-label={`Remove ${props.label} filter`}
       >
-        <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-          <title>Remove filter</title>
-          <path
-            fill-rule="evenodd"
-            d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-            clip-rule="evenodd"
-          />
-        </svg>
+        <X class="w-3 h-3" aria-hidden="true" />
       </button>
     </span>
   );
@@ -181,20 +175,10 @@ const FilterDropdown: Component<{
             {props.selectedItems.length}
           </span>
         </Show>
-        <svg
+        <ChevronDown
           class={`w-4 h-4 transition-transform ${isOpen() ? "rotate-180" : ""}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <title>Toggle dropdown</title>
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+          aria-hidden="true"
+        />
       </button>
 
       <Show when={isOpen()}>
@@ -300,20 +284,10 @@ const TuneSetFilterDropdown: Component<{
             {props.selectedTuneSetIds.length}
           </span>
         </Show>
-        <svg
+        <ChevronDown
           class={`w-4 h-4 transition-transform ${isOpen() ? "rotate-180" : ""}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <title>Toggle dropdown</title>
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+          aria-hidden="true"
+        />
       </button>
 
       <Show when={isOpen()}>
@@ -598,40 +572,17 @@ export const FilterPanel: Component<FilterPanelProps> = (props) => {
         aria-haspopup="true"
         data-testid="filters-button"
       >
-        <svg
-          class="w-3.5 h-3.5 flex-shrink-0"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
-          />
-        </svg>
+        <Filter class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
         <span class="hidden sm:inline">Filters</span>
         <Show when={totalSelected() > 0}>
           <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 font-medium">
             {totalSelected()}
           </span>
         </Show>
-        <svg
+        <ChevronDown
           class={`w-3.5 h-3.5 hidden sm:inline transition-transform ${isExpanded() ? "rotate-180" : ""}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <title>Toggle filters</title>
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+          aria-hidden="true"
+        />
       </button>
 
       {/* Collapsible filter panel */}

--- a/src/components/groups/GroupsManagerDialog.tsx
+++ b/src/components/groups/GroupsManagerDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "solid-js";
 import { toast } from "solid-sonner";
 import { ProgramBuilderDialog } from "@/components/groups/ProgramBuilderDialog";
+import { Button } from "@/components/ui/button";
 import { useGroupsDialog } from "@/contexts/GroupsDialogContext";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useCurrentTuneSet } from "@/lib/context/CurrentTuneSetContext";
@@ -107,15 +108,16 @@ const GroupDialog: Component<GroupDialogProps> = (props) => {
               programs.
             </p>
           </div>
-          <button
+          <Button
             type="button"
             onClick={props.onClose}
-            class="rounded-md px-2 py-1 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            variant="ghost"
+            size="sm"
             aria-label="Close create group dialog"
             data-testid="close-group-dialog-button"
           >
             Close
-          </button>
+          </Button>
         </div>
 
         <div class="mt-4 space-y-4">
@@ -158,17 +160,17 @@ const GroupDialog: Component<GroupDialogProps> = (props) => {
             <p class="text-sm text-red-600 dark:text-red-400">{props.error}</p>
           </Show>
 
-          <div class="flex justify-end gap-3 border-t border-gray-200 pt-4 dark:border-gray-700">
-            <button
+          <div class="flex w-full justify-between gap-3 border-t border-gray-200 pt-4 dark:border-gray-700">
+            <Button
               type="button"
               onClick={props.onClose}
               disabled={props.isSaving}
-              class="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+              variant="outline"
               data-testid="cancel-group-button"
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               onClick={() =>
                 props.onSubmit({
@@ -177,13 +179,13 @@ const GroupDialog: Component<GroupDialogProps> = (props) => {
                 })
               }
               disabled={props.isSaving}
-              class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+              variant="default"
               data-testid="save-group-button"
             >
               <Show when={props.isSaving} fallback="Create Group">
                 Creating...
               </Show>
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -244,7 +246,7 @@ const ManageableGroupMemberRow: Component<{
         }
       >
         <div class="absolute right-4 top-4 flex items-center gap-2">
-          <button
+          <Button
             type="button"
             onClick={() =>
               props.onRoleChange(
@@ -252,7 +254,9 @@ const ManageableGroupMemberRow: Component<{
               )
             }
             disabled={props.isBusy}
-            class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-gray-300 bg-white text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            variant="outline"
+            size="icon"
+            class="h-9 w-9"
             data-testid="group-member-role-select"
             title={
               props.member.role === "admin"
@@ -271,18 +275,20 @@ const ManageableGroupMemberRow: Component<{
             >
               <Shield size={16} />
             </Show>
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={props.onRemove}
             disabled={props.isBusy}
-            class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-red-200 text-red-700 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/40"
+            variant="ghost"
+            size="icon"
+            class="h-9 w-9 text-destructive hover:bg-destructive/10 hover:text-destructive"
             data-testid="remove-group-member-button"
             title="Remove member"
             aria-label="Remove member"
           >
             <Trash2 size={16} />
-          </button>
+          </Button>
         </div>
       </Show>
     </div>
@@ -325,17 +331,19 @@ const GroupMemberCandidateRow: Component<{
         }
       >
         <div class="absolute right-4 top-4 flex items-center gap-2">
-          <button
+          <Button
             type="button"
             onClick={() => props.onAdd(props.candidate.userRef)}
             disabled={props.isAdding}
-            class="inline-flex h-9 w-9 items-center justify-center rounded-md bg-blue-600 text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+            variant="default"
+            size="icon"
+            class="h-9 w-9"
             data-testid="add-group-member-button"
             title="Add member"
             aria-label="Add member"
           >
             <Plus size={16} />
-          </button>
+          </Button>
         </div>
       </Show>
     </div>
@@ -638,15 +646,16 @@ const GroupsManagerContent: Component = () => {
                 programs.
               </p>
             </div>
-            <button
+            <Button
               type="button"
-              class="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+              class="inline-flex items-center justify-center gap-2"
+              variant="default"
               onClick={() => setShowCreateGroupDialog(true)}
               data-testid="open-create-group-button"
             >
               <span aria-hidden="true">+</span>
               New Group
-            </button>
+            </Button>
           </div>
 
           <Show
@@ -660,26 +669,27 @@ const GroupsManagerContent: Component = () => {
             <Show
               when={(groups() ?? []).length > 0}
               fallback={
-                <div class="rounded-xl border border-dashed border-gray-300 bg-white p-10 text-center dark:border-gray-700 dark:bg-gray-800">
-                  <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-300">
+                <div class="rounded-xl border border-dashed border-border bg-background p-10 text-center">
+                  <div class="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-muted text-muted-foreground">
                     <span aria-hidden="true">+</span>
                   </div>
-                  <h3 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+                  <h3 class="mt-4 text-lg font-semibold text-foreground">
                     No groups yet
                   </h3>
-                  <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                  <p class="mt-2 text-sm text-muted-foreground">
                     Start by creating a group so you can attach shared programs
                     to it.
                   </p>
-                  <button
+                  <Button
                     type="button"
-                    class="mt-5 inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                    class="mt-5 inline-flex items-center gap-2"
+                    variant="outline"
                     onClick={() => setShowCreateGroupDialog(true)}
                     data-testid="empty-create-group-button"
                   >
                     <span aria-hidden="true">+</span>
                     Create Your First Group
-                  </button>
+                  </Button>
                 </div>
               }
             >
@@ -697,8 +707,8 @@ const GroupsManagerContent: Component = () => {
                           type="button"
                           class={`mb-2 flex w-full items-start justify-between rounded-lg border px-3 py-3 text-left last:mb-0 ${
                             selectedGroupId() === group.id
-                              ? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30"
-                              : "border-gray-200 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/60"
+                              ? "border-primary bg-primary/5"
+                              : "border-border hover:bg-accent/30"
                           }`}
                           onClick={() => setSelectedGroupId(group.id)}
                           data-testid="group-list-item"

--- a/src/components/groups/GroupsManagerDialog.tsx
+++ b/src/components/groups/GroupsManagerDialog.tsx
@@ -1,4 +1,13 @@
-import { Crown, Plus, Shield, Trash2, User, X } from "lucide-solid";
+import {
+  CalendarDays,
+  Crown,
+  Mail,
+  Plus,
+  Shield,
+  SquarePen,
+  Trash2,
+  User,
+} from "lucide-solid";
 import type { Component } from "solid-js";
 import {
   createEffect,
@@ -11,6 +20,12 @@ import {
 } from "solid-js";
 import { toast } from "solid-sonner";
 import { ProgramBuilderDialog } from "@/components/groups/ProgramBuilderDialog";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { useGroupsDialog } from "@/contexts/GroupsDialogContext";
 import { useAuth } from "@/lib/auth/AuthContext";
@@ -84,7 +99,6 @@ const GroupDialog: Component<GroupDialogProps> = (props) => {
         type="button"
         class="fixed inset-0 z-[60] bg-black/50 dark:bg-black/70"
         onClick={props.onClose}
-        aria-label="Close create group dialog backdrop"
         data-testid="group-dialog-backdrop"
       />
 
@@ -95,32 +109,59 @@ const GroupDialog: Component<GroupDialogProps> = (props) => {
         aria-labelledby="group-dialog-title"
         data-testid="group-dialog"
       >
-        <div class="flex items-start justify-between gap-4">
-          <div>
+        <header class="flex justify-between items-center w-full mb-4">
+          <div class="flex flex-1 justify-start">
+            <Button
+              type="button"
+              onClick={props.onClose}
+              disabled={props.isSaving}
+              variant="outline"
+              data-testid="cancel-group-button"
+            >
+              Cancel
+            </Button>
+          </div>
+          <div class="flex min-w-0 flex-1 justify-center px-3">
             <h2
               id="group-dialog-title"
-              class="text-xl font-semibold text-gray-900 dark:text-white"
+              class="text-center text-xl font-semibold text-gray-900 dark:text-white"
             >
               Create Group
             </h2>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              Create a group space for shared membership and group-owned
-              programs.
-            </p>
           </div>
-          <Button
-            type="button"
-            onClick={props.onClose}
-            variant="ghost"
-            size="sm"
-            aria-label="Close create group dialog"
-            data-testid="close-group-dialog-button"
-          >
-            Close
-          </Button>
-        </div>
+          <div class="flex flex-1 justify-end">
+            <Button
+              type="button"
+              onClick={() =>
+                props.onSubmit({
+                  name: name(),
+                  description: description(),
+                })
+              }
+              disabled={props.isSaving}
+              variant="default"
+              data-testid="save-group-button"
+            >
+              <Show
+                when={props.isSaving}
+                fallback={
+                  <>
+                    <Plus class="h-4 w-4" />
+                    Create
+                  </>
+                }
+              >
+                Creating...
+              </Show>
+            </Button>
+          </div>
+        </header>
 
-        <div class="mt-4 space-y-4">
+        <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+          Create a group space for shared membership and group-owned programs.
+        </p>
+
+        <div class="space-y-4">
           <div class="space-y-2">
             <label
               for="group-name"
@@ -159,37 +200,110 @@ const GroupDialog: Component<GroupDialogProps> = (props) => {
           <Show when={props.error}>
             <p class="text-sm text-red-600 dark:text-red-400">{props.error}</p>
           </Show>
-
-          <div class="flex w-full justify-between gap-3 border-t border-gray-200 pt-4 dark:border-gray-700">
-            <Button
-              type="button"
-              onClick={props.onClose}
-              disabled={props.isSaving}
-              variant="outline"
-              data-testid="cancel-group-button"
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              onClick={() =>
-                props.onSubmit({
-                  name: name(),
-                  description: description(),
-                })
-              }
-              disabled={props.isSaving}
-              variant="default"
-              data-testid="save-group-button"
-            >
-              <Show when={props.isSaving} fallback="Create Group">
-                Creating...
-              </Show>
-            </Button>
-          </div>
         </div>
       </div>
     </Show>
+  );
+};
+
+const formatMemberDate = (value: string) =>
+  new Date(value).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+const getMemberDisplayName = (member: GroupMemberWithProfile) =>
+  member.profileName ?? member.profileEmail ?? "Unknown member";
+
+const MemberInfoDialog: Component<{
+  member: GroupMemberWithProfile | null;
+  isOpen: boolean;
+  onClose: () => void;
+}> = (props) => {
+  return (
+    <AlertDialog
+      open={props.isOpen}
+      onOpenChange={(open) => !open && props.onClose()}
+    >
+      <AlertDialogContent class="max-w-md bg-white dark:bg-gray-900">
+        <header class="flex justify-between items-center w-full mb-4">
+          <div class="flex flex-1 justify-start">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={props.onClose}
+            >
+              Back
+            </Button>
+          </div>
+          <div class="flex min-w-0 flex-1 justify-center px-3">
+            <AlertDialogTitle class="text-center">
+              Member Details
+            </AlertDialogTitle>
+          </div>
+          <div class="flex flex-1 justify-end" />
+        </header>
+
+        <Show when={props.member}>
+          {(member) => (
+            <div class="space-y-4">
+              <AlertDialogDescription>
+                Profile information currently available for this group member.
+              </AlertDialogDescription>
+
+              <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60">
+                <div class="text-lg font-semibold text-gray-900 dark:text-white">
+                  {getMemberDisplayName(member())}
+                </div>
+                <div class="mt-2 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium capitalize bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                  <Show
+                    when={member().effectiveRole === "owner"}
+                    fallback={null}
+                  >
+                    <Crown size={12} />
+                  </Show>
+                  {member().effectiveRole}
+                </div>
+              </div>
+
+              <div class="space-y-3 text-sm text-gray-600 dark:text-gray-300">
+                <div class="flex items-start gap-3">
+                  <Mail size={16} class="mt-0.5 text-gray-400" />
+                  <div>
+                    <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Email
+                    </div>
+                    <div>{member().profileEmail ?? "No email available"}</div>
+                  </div>
+                </div>
+
+                <div class="flex items-start gap-3">
+                  <User size={16} class="mt-0.5 text-gray-400" />
+                  <div>
+                    <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      User ID
+                    </div>
+                    <div class="break-all">{member().userRef}</div>
+                  </div>
+                </div>
+
+                <div class="flex items-start gap-3">
+                  <CalendarDays size={16} class="mt-0.5 text-gray-400" />
+                  <div>
+                    <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Joined
+                    </div>
+                    <div>{formatMemberDate(member().joinedAt)}</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </Show>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };
 
@@ -199,40 +313,25 @@ const ManageableGroupMemberRow: Component<{
   isBusy: boolean;
   onRoleChange: (role: "admin" | "member") => void;
   onRemove: () => void;
+  onShowInfo: () => void;
 }> = (props) => {
   return (
-    <div class="relative rounded-lg border border-gray-200 px-4 py-4 dark:border-gray-700">
-      <div class="min-w-0 pr-28">
-        <div class="text-base font-medium leading-tight text-gray-900 dark:text-white">
-          {props.member.profileName ??
-            props.member.profileEmail ??
-            "Unknown member"}
-        </div>
-        <div class="mt-2 text-sm text-gray-400 dark:text-gray-400">
-          <Show
-            when={props.member.isOwner}
-            fallback={
-              <>
-                <Show when={props.member.profileEmail}>
-                  <div class="truncate">{props.member.profileEmail}</div>
-                </Show>
-                <div>
-                  Joined {new Date(props.member.joinedAt).toLocaleDateString()}
-                </div>
-              </>
-            }
-          >
-            Group owner
-          </Show>
-        </div>
-      </div>
+    <div class="rounded-lg border border-gray-200 px-4 py-4 dark:border-gray-700">
+      <div class="flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={props.onShowInfo}
+          class="min-w-0 truncate text-left text-base font-medium leading-tight text-gray-900 hover:underline dark:text-white"
+          data-testid="group-member-name-button"
+        >
+          {getMemberDisplayName(props.member)}
+        </button>
 
-      <Show
-        when={props.canManage && !props.member.isOwner}
-        fallback={
-          <div class="absolute right-4 top-4">
+        <Show
+          when={props.canManage && !props.member.isOwner}
+          fallback={
             <span
-              class={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium capitalize ${roleBadgeClass(props.member.effectiveRole)}`}
+              class={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium capitalize shrink-0 ${roleBadgeClass(props.member.effectiveRole)}`}
             >
               <Show
                 when={props.member.effectiveRole === "owner"}
@@ -242,55 +341,55 @@ const ManageableGroupMemberRow: Component<{
               </Show>
               {props.member.effectiveRole}
             </span>
-          </div>
-        }
-      >
-        <div class="absolute right-4 top-4 flex items-center gap-2">
-          <Button
-            type="button"
-            onClick={() =>
-              props.onRoleChange(
-                props.member.role === "admin" ? "member" : "admin"
-              )
-            }
-            disabled={props.isBusy}
-            variant="outline"
-            size="icon"
-            class="h-9 w-9"
-            data-testid="group-member-role-select"
-            title={
-              props.member.role === "admin"
-                ? "Change to member"
-                : "Change to admin"
-            }
-            aria-label={
-              props.member.role === "admin"
-                ? "Change to member"
-                : "Change to admin"
-            }
-          >
-            <Show
-              when={props.member.role === "admin"}
-              fallback={<User size={16} />}
+          }
+        >
+          <div class="flex items-center gap-2 shrink-0">
+            <Button
+              type="button"
+              onClick={() =>
+                props.onRoleChange(
+                  props.member.role === "admin" ? "member" : "admin"
+                )
+              }
+              disabled={props.isBusy}
+              variant="outline"
+              size="icon"
+              class="h-9 w-9"
+              data-testid="group-member-role-select"
+              title={
+                props.member.role === "admin"
+                  ? "Change to member"
+                  : "Change to admin"
+              }
+              aria-label={
+                props.member.role === "admin"
+                  ? "Change to member"
+                  : "Change to admin"
+              }
             >
-              <Shield size={16} />
-            </Show>
-          </Button>
-          <Button
-            type="button"
-            onClick={props.onRemove}
-            disabled={props.isBusy}
-            variant="ghost"
-            size="icon"
-            class="h-9 w-9 text-destructive hover:bg-destructive/10 hover:text-destructive"
-            data-testid="remove-group-member-button"
-            title="Remove member"
-            aria-label="Remove member"
-          >
-            <Trash2 size={16} />
-          </Button>
-        </div>
-      </Show>
+              <Show
+                when={props.member.role === "admin"}
+                fallback={<User size={16} />}
+              >
+                <Shield size={16} />
+              </Show>
+            </Button>
+            <Button
+              type="button"
+              onClick={props.onRemove}
+              disabled={props.isBusy}
+              variant="ghost"
+              size="icon"
+              class="h-9 w-9 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              data-testid="remove-group-member-button"
+              title="Remove member"
+              aria-label="Remove member"
+            >
+              <Trash2 size={16} />
+            </Button>
+          </div>
+        </Show>
+      </div>
     </div>
   );
 };
@@ -298,7 +397,7 @@ const ManageableGroupMemberRow: Component<{
 const GroupMemberCandidateRow: Component<{
   candidate: GroupMemberCandidate;
   isAdding: boolean;
-  onAdd: (userRef: string) => void;
+  onAdd: (candidate: GroupMemberCandidate) => void;
 }> = (props) => {
   return (
     <div class="relative rounded-lg border border-gray-200 px-4 py-4 dark:border-gray-700">
@@ -333,7 +432,7 @@ const GroupMemberCandidateRow: Component<{
         <div class="absolute right-4 top-4 flex items-center gap-2">
           <Button
             type="button"
-            onClick={() => props.onAdd(props.candidate.userRef)}
+            onClick={() => props.onAdd(props.candidate)}
             disabled={props.isAdding}
             variant="default"
             size="icon"
@@ -350,7 +449,7 @@ const GroupMemberCandidateRow: Component<{
   );
 };
 
-const GroupsManagerContent: Component = () => {
+const GroupsManagerContent: Component<{ onClose: () => void }> = (props) => {
   const { user, localDb } = useAuth();
   const { tuneSetListChanged, incrementTuneSetListChanged } =
     useCurrentTuneSet();
@@ -367,6 +466,9 @@ const GroupsManagerContent: Component = () => {
   const [editingProgramId, setEditingProgramId] = createSignal<
     string | undefined
   >(undefined);
+  const [programDialogMode, setProgramDialogMode] = createSignal<
+    "view" | "edit"
+  >("edit");
   const [deletingProgramId, setDeletingProgramId] = createSignal<string | null>(
     null
   );
@@ -375,6 +477,8 @@ const GroupsManagerContent: Component = () => {
   const [busyMembershipId, setBusyMembershipId] = createSignal<string | null>(
     null
   );
+  const [selectedMemberInfo, setSelectedMemberInfo] =
+    createSignal<GroupMemberWithProfile | null>(null);
 
   const [groups] = createResource(
     () => {
@@ -507,11 +611,19 @@ const GroupsManagerContent: Component = () => {
   };
 
   const handleOpenNewProgram = () => {
+    setProgramDialogMode("edit");
     setEditingProgramId(undefined);
     setShowProgramEditor(true);
   };
 
   const handleOpenExistingProgram = (program: ProgramWithSummary) => {
+    setProgramDialogMode("edit");
+    setEditingProgramId(program.id);
+    setShowProgramEditor(true);
+  };
+
+  const handleOpenProgramDetails = (program: ProgramWithSummary) => {
+    setProgramDialogMode("view");
     setEditingProgramId(program.id);
     setShowProgramEditor(true);
   };
@@ -548,7 +660,7 @@ const GroupsManagerContent: Component = () => {
     }
   };
 
-  const handleAddMember = async (memberUserId: string) => {
+  const handleAddMember = async (candidate: GroupMemberCandidate) => {
     const db = localDb();
     const userId = user()?.id;
     const groupId = selectedGroupId();
@@ -559,9 +671,11 @@ const GroupsManagerContent: Component = () => {
 
     try {
       setIsAddingMember(true);
-      await addGroupMember(db, groupId, userId, memberUserId, "member");
+      await addGroupMember(db, groupId, userId, candidate.userRef, "member", {
+        profileName: candidate.profileName,
+        profileEmail: candidate.profileEmail,
+      });
       setGroupListVersion((value) => value + 1);
-      setMemberSearchTerm("");
       toast.success("Added group member.", { duration: 2500 });
     } catch (error) {
       toast.error(
@@ -637,26 +751,45 @@ const GroupsManagerContent: Component = () => {
 
   return (
     <>
-      <div class="flex h-full flex-col bg-white dark:bg-gray-800">
-        <div class="flex-1 overflow-auto bg-gray-50 p-4 dark:bg-gray-900 sm:p-6">
-          <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <p class="max-w-2xl text-sm text-gray-600 dark:text-gray-400">
-                Create groups, review current membership, and manage shared
-                programs.
-              </p>
+      <div class="flex h-full min-h-0 flex-col bg-white dark:bg-gray-800">
+        <div class="flex min-h-0 flex-1 flex-col bg-gray-50 p-4 dark:bg-gray-900 sm:p-6">
+          <header class="mb-6 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-4">
+            <div class="flex items-center justify-start">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={props.onClose}
+                data-testid="groups-close-button"
+              >
+                Cancel
+              </Button>
             </div>
-            <Button
-              type="button"
-              class="inline-flex items-center justify-center gap-2"
-              variant="default"
-              onClick={() => setShowCreateGroupDialog(true)}
-              data-testid="open-create-group-button"
-            >
-              <span aria-hidden="true">+</span>
-              New Group
-            </Button>
-          </div>
+            <div class="flex min-w-0 items-center justify-center px-3">
+              <h2
+                id="groups-dialog-title"
+                class="text-center text-xl font-semibold text-gray-900 dark:text-gray-100 md:text-2xl"
+              >
+                Groups
+              </h2>
+            </div>
+            <div class="flex items-center justify-end">
+              <Button
+                type="button"
+                class="inline-flex items-center justify-center gap-2"
+                variant="default"
+                onClick={() => setShowCreateGroupDialog(true)}
+                data-testid="open-create-group-button"
+              >
+                <Plus size={16} />
+                New Group
+              </Button>
+            </div>
+          </header>
+
+          <p class="mb-6 max-w-2xl text-sm text-gray-600 dark:text-gray-400">
+            Create groups, review current membership, and manage shared
+            programs.
+          </p>
 
           <Show
             when={!groups.loading}
@@ -693,14 +826,17 @@ const GroupsManagerContent: Component = () => {
                 </div>
               }
             >
-              <div class="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
-                <section class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+              <div class="grid min-h-0 flex-1 gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
+                <section class="flex min-h-0 flex-col rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
                   <div class="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
                     <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                       Your Groups
                     </h3>
                   </div>
-                  <div class="p-2" data-testid="groups-list">
+                  <div
+                    class="min-h-0 flex-1 overflow-y-auto p-2"
+                    data-testid="groups-list"
+                  >
                     <For each={groups() ?? []}>
                       {(group) => (
                         <button
@@ -737,7 +873,7 @@ const GroupsManagerContent: Component = () => {
                   {(groupAccessor) => {
                     const group = groupAccessor();
                     return (
-                      <section class="space-y-6">
+                      <section class="grid min-h-0 gap-6 grid-rows-[auto_minmax(0,1fr)]">
                         <div class="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
                           <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                             <div>
@@ -754,19 +890,19 @@ const GroupsManagerContent: Component = () => {
                           </div>
                         </div>
 
-                        <div class="grid gap-6 xl:grid-cols-[minmax(0,340px)_minmax(0,1fr)]">
-                          <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+                        <div class="grid min-h-0 gap-6 xl:grid-cols-[minmax(0,340px)_minmax(0,1fr)]">
+                          <div class="flex min-h-0 flex-col rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
                             <div class="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
                               <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                                 Members and Roles
                               </h3>
                             </div>
                             <div
-                              class="space-y-3 p-4"
+                              class="flex min-h-0 flex-1 flex-col gap-3 p-4"
                               data-testid="group-members-list"
                             >
                               <Show when={group.canManageMembership}>
-                                <div class="rounded-lg border border-dashed border-gray-300 p-3 dark:border-gray-700">
+                                <div class="shrink-0 rounded-lg border border-dashed border-gray-300 p-3 dark:border-gray-700">
                                   <div class="flex flex-col gap-3">
                                     <div class="flex flex-col gap-2">
                                       <input
@@ -818,24 +954,26 @@ const GroupsManagerContent: Component = () => {
                                           }
                                         >
                                           <div
-                                            class="space-y-2"
+                                            class="max-h-72 overflow-y-auto rounded-lg border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-900"
                                             data-testid="group-member-candidate-list"
                                           >
-                                            <For
-                                              each={memberCandidates() ?? []}
-                                            >
-                                              {(candidate) => (
-                                                <GroupMemberCandidateRow
-                                                  candidate={candidate}
-                                                  isAdding={isAddingMember()}
-                                                  onAdd={(userRef) =>
-                                                    void handleAddMember(
-                                                      userRef
-                                                    )
-                                                  }
-                                                />
-                                              )}
-                                            </For>
+                                            <div class="space-y-2">
+                                              <For
+                                                each={memberCandidates() ?? []}
+                                              >
+                                                {(candidate) => (
+                                                  <GroupMemberCandidateRow
+                                                    candidate={candidate}
+                                                    isAdding={isAddingMember()}
+                                                    onAdd={(nextCandidate) =>
+                                                      void handleAddMember(
+                                                        nextCandidate
+                                                      )
+                                                    }
+                                                  />
+                                                )}
+                                              </For>
+                                            </div>
                                           </div>
                                         </Show>
                                       </Show>
@@ -844,40 +982,47 @@ const GroupsManagerContent: Component = () => {
                                 </div>
                               </Show>
 
-                              <Show
-                                when={!groupMembers.loading}
-                                fallback={
-                                  <div class="text-sm text-gray-500 dark:text-gray-400">
-                                    Loading members...
+                              <div class="min-h-0 flex-1 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/50">
+                                <Show
+                                  when={!groupMembers.loading}
+                                  fallback={
+                                    <div class="text-sm text-gray-500 dark:text-gray-400">
+                                      Loading members...
+                                    </div>
+                                  }
+                                >
+                                  <div class="space-y-3">
+                                    <For each={groupMembers() ?? []}>
+                                      {(member) => (
+                                        <ManageableGroupMemberRow
+                                          member={member}
+                                          canManage={group.canManageMembership}
+                                          isBusy={
+                                            busyMembershipId() ===
+                                            member.membershipId
+                                          }
+                                          onRoleChange={(role) =>
+                                            void handleUpdateMemberRole(
+                                              member,
+                                              role
+                                            )
+                                          }
+                                          onRemove={() =>
+                                            void handleRemoveMember(member)
+                                          }
+                                          onShowInfo={() =>
+                                            setSelectedMemberInfo(member)
+                                          }
+                                        />
+                                      )}
+                                    </For>
                                   </div>
-                                }
-                              >
-                                <For each={groupMembers() ?? []}>
-                                  {(member) => (
-                                    <ManageableGroupMemberRow
-                                      member={member}
-                                      canManage={group.canManageMembership}
-                                      isBusy={
-                                        busyMembershipId() ===
-                                        member.membershipId
-                                      }
-                                      onRoleChange={(role) =>
-                                        void handleUpdateMemberRole(
-                                          member,
-                                          role
-                                        )
-                                      }
-                                      onRemove={() =>
-                                        void handleRemoveMember(member)
-                                      }
-                                    />
-                                  )}
-                                </For>
-                              </Show>
+                                </Show>
+                              </div>
                             </div>
                           </div>
 
-                          <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+                          <div class="flex min-h-0 flex-col rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
                             <div class="flex flex-col gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between">
                               <div>
                                 <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
@@ -902,59 +1047,116 @@ const GroupsManagerContent: Component = () => {
                               </Show>
                             </div>
 
-                            <div class="p-4">
+                            <div class="flex min-h-0 flex-1 flex-col p-4">
                               <Show when={groupPrograms.error}>
                                 <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-200">
                                   Failed to load programs.
                                 </div>
                               </Show>
-                              <Show
-                                when={
-                                  !groupPrograms.loading ||
-                                  visibleGroupPrograms().length > 0 ||
-                                  Boolean(groupPrograms.error)
-                                }
-                                fallback={
-                                  <div class="text-sm text-gray-500 dark:text-gray-400">
-                                    Loading programs...
-                                  </div>
-                                }
-                              >
+
+                              <div class="min-h-0 flex-1 overflow-y-auto rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/50">
                                 <Show
-                                  when={visibleGroupPrograms().length > 0}
+                                  when={
+                                    !groupPrograms.loading ||
+                                    visibleGroupPrograms().length > 0 ||
+                                    Boolean(groupPrograms.error)
+                                  }
                                   fallback={
-                                    <div class="rounded-lg border border-dashed border-gray-300 px-4 py-8 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                                      <Show
-                                        when={groupPrograms.loading}
-                                        fallback="No shared programs yet."
-                                      >
-                                        Refreshing programs...
-                                      </Show>
+                                    <div class="text-sm text-gray-500 dark:text-gray-400">
+                                      Loading programs...
                                     </div>
                                   }
                                 >
-                                  <div
-                                    class="space-y-3"
-                                    data-testid="group-programs-list"
+                                  <Show
+                                    when={visibleGroupPrograms().length > 0}
+                                    fallback={
+                                      <div class="rounded-lg border border-dashed border-gray-300 px-4 py-8 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                                        <Show
+                                          when={groupPrograms.loading}
+                                          fallback="No shared programs yet."
+                                        >
+                                          Refreshing programs...
+                                        </Show>
+                                      </div>
+                                    }
                                   >
-                                    <For each={visibleGroupPrograms()}>
-                                      {(programRow) => (
-                                        <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
-                                          <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                                            <button
-                                              type="button"
-                                              class="min-w-0 text-left"
-                                              onClick={() =>
-                                                handleOpenExistingProgram(
-                                                  programRow
-                                                )
-                                              }
-                                              data-testid="open-group-program-button"
-                                            >
-                                              <div class="truncate text-sm font-semibold text-gray-900 dark:text-white">
-                                                {programRow.name}
+                                    <div
+                                      class="space-y-3"
+                                      data-testid="group-programs-list"
+                                    >
+                                      <For each={visibleGroupPrograms()}>
+                                        {(programRow) => (
+                                          <div class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+                                            <div class="flex items-center justify-between gap-3">
+                                              <button
+                                                type="button"
+                                                class="min-w-0 flex-1 text-left"
+                                                onClick={() =>
+                                                  handleOpenProgramDetails(
+                                                    programRow
+                                                  )
+                                                }
+                                                data-testid="open-group-program-button"
+                                              >
+                                                <div class="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                                                  {programRow.name}
+                                                </div>
+                                              </button>
+
+                                              <div class="flex shrink-0 items-center gap-2">
+                                                <button
+                                                  type="button"
+                                                  class="inline-flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                                                  onClick={() =>
+                                                    handleOpenExistingProgram(
+                                                      programRow
+                                                    )
+                                                  }
+                                                  data-testid="view-group-program-button"
+                                                >
+                                                  <Show
+                                                    when={programRow.canManage}
+                                                    fallback="View"
+                                                  >
+                                                    <SquarePen size={14} />
+                                                    Edit
+                                                  </Show>
+                                                </button>
+                                                <Show
+                                                  when={programRow.canManage}
+                                                >
+                                                  <button
+                                                    type="button"
+                                                    class="rounded-md border border-red-200 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/40"
+                                                    disabled={
+                                                      deletingProgramId() ===
+                                                      programRow.id
+                                                    }
+                                                    onClick={() =>
+                                                      void handleDeleteProgram(
+                                                        programRow
+                                                      )
+                                                    }
+                                                    data-testid="delete-group-program-button"
+                                                  >
+                                                    <Show
+                                                      when={
+                                                        deletingProgramId() ===
+                                                        programRow.id
+                                                      }
+                                                      fallback={
+                                                        <Trash2 size={14} />
+                                                      }
+                                                    >
+                                                      Deleting...
+                                                    </Show>
+                                                  </button>
+                                                </Show>
                                               </div>
-                                              <div class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                            </div>
+
+                                            <div class="mt-3">
+                                              <div class="text-sm text-gray-600 dark:text-gray-400">
                                                 {programRow.description ||
                                                   "No description yet."}
                                               </div>
@@ -964,59 +1166,14 @@ const GroupsManagerContent: Component = () => {
                                                   ? ""
                                                   : "s"}
                                               </div>
-                                            </button>
-
-                                            <div class="flex items-center gap-2">
-                                              <button
-                                                type="button"
-                                                class="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
-                                                onClick={() =>
-                                                  handleOpenExistingProgram(
-                                                    programRow
-                                                  )
-                                                }
-                                                data-testid="view-group-program-button"
-                                              >
-                                                {programRow.canManage
-                                                  ? "Edit"
-                                                  : "View"}
-                                              </button>
-                                              <Show when={programRow.canManage}>
-                                                <button
-                                                  type="button"
-                                                  class="rounded-md border border-red-200 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/40"
-                                                  disabled={
-                                                    deletingProgramId() ===
-                                                    programRow.id
-                                                  }
-                                                  onClick={() =>
-                                                    void handleDeleteProgram(
-                                                      programRow
-                                                    )
-                                                  }
-                                                  data-testid="delete-group-program-button"
-                                                >
-                                                  <Show
-                                                    when={
-                                                      deletingProgramId() ===
-                                                      programRow.id
-                                                    }
-                                                    fallback={
-                                                      <Trash2 size={14} />
-                                                    }
-                                                  >
-                                                    Deleting...
-                                                  </Show>
-                                                </button>
-                                              </Show>
                                             </div>
                                           </div>
-                                        </div>
-                                      )}
-                                    </For>
-                                  </div>
+                                        )}
+                                      </For>
+                                    </div>
+                                  </Show>
                                 </Show>
-                              </Show>
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -1048,13 +1205,21 @@ const GroupsManagerContent: Component = () => {
         onClose={() => {
           setShowProgramEditor(false);
           setEditingProgramId(undefined);
+          setProgramDialogMode("edit");
         }}
         programId={editingProgramId()}
+        forceViewMode={programDialogMode() === "view"}
         onSaved={() => {
           incrementTuneSetListChanged();
           void refetchGroupPrograms();
         }}
         groupRef={selectedGroupId()}
+      />
+
+      <MemberInfoDialog
+        member={selectedMemberInfo()}
+        isOpen={selectedMemberInfo() !== null}
+        onClose={() => setSelectedMemberInfo(null)}
       />
     </>
   );
@@ -1099,40 +1264,15 @@ export const GroupsManagerDialog: Component<GroupsManagerDialogProps> = (
       >
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: Click only stops propagation inside modal shell */}
         <div
-          class="mx-2 flex h-[calc(100vh-1rem)] w-full max-w-full flex-col rounded-lg border border-gray-200 bg-white shadow-2xl pointer-events-auto dark:border-gray-700 dark:bg-gray-800 md:max-h-[calc(100vh-8rem)] md:max-w-6xl"
+          class="mx-2 flex h-[calc(100vh-1rem)] w-full max-w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-2xl pointer-events-auto dark:border-gray-700 dark:bg-gray-800 md:h-[calc(100vh-4rem)] md:max-w-6xl"
           role="dialog"
           aria-labelledby="groups-dialog-title"
           aria-modal="true"
           onClick={(event) => event.stopPropagation()}
           data-testid="groups-modal"
         >
-          <div class="flex items-start justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700 md:px-6 md:py-4">
-            <div>
-              <h2
-                id="groups-dialog-title"
-                class="text-xl font-semibold text-gray-900 dark:text-gray-100 md:text-2xl"
-              >
-                Groups
-              </h2>
-              <p class="mt-1 hidden text-sm text-gray-500 dark:text-gray-400 md:block">
-                Manage group membership and shared programs without leaving your
-                current page.
-              </p>
-            </div>
-
-            <button
-              type="button"
-              onClick={closeDialog}
-              class="relative z-10 flex h-10 w-10 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-              aria-label="Close groups"
-              data-testid="groups-close-button"
-            >
-              <X size={20} />
-            </button>
-          </div>
-
           <div class="min-h-0 flex-1 overflow-hidden">
-            <GroupsManagerContent />
+            <GroupsManagerContent onClose={closeDialog} />
           </div>
         </div>
       </div>

--- a/src/components/groups/GroupsManagerDialog.tsx
+++ b/src/components/groups/GroupsManagerDialog.tsx
@@ -99,6 +99,7 @@ const GroupDialog: Component<GroupDialogProps> = (props) => {
         type="button"
         class="fixed inset-0 z-[60] bg-black/50 dark:bg-black/70"
         onClick={props.onClose}
+        aria-label="Close dialog"
         data-testid="group-dialog-backdrop"
       />
 

--- a/src/components/groups/ProgramBuilderDialog.tsx
+++ b/src/components/groups/ProgramBuilderDialog.tsx
@@ -1,4 +1,4 @@
-import { CircleX, GripVertical, Plus, Save, Trash2 } from "lucide-solid";
+import { GripVertical, Plus, Save, Trash2 } from "lucide-solid";
 import type { Component } from "solid-js";
 import {
   createEffect,
@@ -10,13 +10,13 @@ import {
   Show,
 } from "solid-js";
 import { toast } from "solid-sonner";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useCurrentTuneSet } from "@/lib/context/CurrentTuneSetContext";
 import {
   addTuneSetToProgram,
   addTuneToProgram,
   createProgram,
-  deleteProgram,
   getEligibleTuneSetsForProgram,
   getProgramAccessForUser,
   getProgramById,
@@ -36,6 +36,7 @@ interface ProgramBuilderDialogProps {
   programId?: string;
   groupRef?: string | null;
   onSaved?: () => void;
+  forceViewMode?: boolean;
 }
 
 interface CandidateItem {
@@ -62,6 +63,7 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
   const { user, localDb } = useAuth();
   const { incrementTuneSetListChanged, tuneSetListChanged } =
     useCurrentTuneSet();
+  let programNameInputRef: HTMLInputElement | undefined;
   const [activeProgramId, setActiveProgramId] = createSignal<
     string | undefined
   >(props.programId);
@@ -198,6 +200,10 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
   });
 
   const canManage = createMemo(() => {
+    if (props.forceViewMode && activeProgramId()) {
+      return false;
+    }
+
     if (!activeProgramId()) {
       return true;
     }
@@ -208,7 +214,44 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
     if (!activeProgramId()) {
       return "Create Program";
     }
+
+    if (props.forceViewMode) {
+      return "Program Details";
+    }
+
     return canManage() ? "Edit Program" : "View Program";
+  });
+
+  const hasValidProgramName = createMemo(
+    () => normalizeMetadataValue(name()) !== ""
+  );
+
+  const isCreatingProgram = createMemo(() => !activeProgramId());
+
+  createEffect(() => {
+    if (
+      !props.isOpen ||
+      props.forceViewMode ||
+      !isCreatingProgram() ||
+      !canManage()
+    ) {
+      return;
+    }
+
+    const focusInput = () => {
+      if (programNameInputRef) {
+        programNameInputRef.focus();
+        programNameInputRef.select();
+      }
+    };
+
+    const animationFrameId = requestAnimationFrame(focusInput);
+    const timeoutId = window.setTimeout(focusInput, 120);
+
+    onCleanup(() => {
+      cancelAnimationFrame(animationFrameId);
+      window.clearTimeout(timeoutId);
+    });
   });
 
   const hasPendingMetadataChanges = createMemo(() => {
@@ -318,6 +361,10 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
   const ensureProgramId = async (): Promise<string | null> => {
     if (activeProgramId()) {
       return activeProgramId()!;
+    }
+
+    if (!hasValidProgramName()) {
+      return null;
     }
 
     const created = await persistProgramMetadata();
@@ -442,41 +489,6 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
     }
   };
 
-  const handleDeleteProgram = async () => {
-    const db = localDb();
-    const userId = user()?.id;
-    const programId = activeProgramId();
-    const currentProgram = program();
-    if (!db || !userId || !programId || !currentProgram) {
-      showDialogError("Database is not ready yet.");
-      return;
-    }
-
-    const confirmed = window.confirm(
-      `Delete the program "${currentProgram.name}"?`
-    );
-    if (!confirmed) {
-      return;
-    }
-
-    try {
-      setIsSaving(true);
-      await deleteProgram(db, programId, userId);
-      incrementTuneSetListChanged();
-      props.onSaved?.();
-      props.onClose();
-      toast.success(`Deleted program "${currentProgram.name}".`, {
-        duration: 2500,
-      });
-    } catch (error) {
-      showDialogError(
-        error instanceof Error ? error.message : "Failed to delete Program"
-      );
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
   return (
     <Show when={props.isOpen}>
       <button
@@ -494,91 +506,122 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
         aria-labelledby="program-builder-title"
         data-testid="program-builder-dialog"
       >
-        <div class="flex items-start justify-between gap-4 border-b border-gray-200 p-4 dark:border-gray-700 sm:p-6">
-          <div>
-            <h2
-              id="program-builder-title"
-              class="text-xl font-semibold text-gray-900 dark:text-white"
-            >
-              {dialogTitle()}
-            </h2>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+        <div class="border-b border-gray-200 p-4 dark:border-gray-700 sm:p-6">
+          <header class="flex justify-between items-center w-full mb-4">
+            <div class="flex flex-1 justify-start">
+              <Button
+                type="button"
+                onClick={() => void handleDone()}
+                disabled={isSaving() || isMutatingItems()}
+                variant={canManage() ? "outline" : "ghost"}
+                size="sm"
+                data-testid="close-program-builder-button"
+              >
+                {canManage() ? "Cancel" : "Back"}
+              </Button>
+            </div>
+            <div class="flex min-w-0 flex-1 justify-center px-3">
+              <h2
+                id="program-builder-title"
+                class="text-center text-xl font-semibold text-gray-900 dark:text-white"
+              >
+                {dialogTitle()}
+              </h2>
+            </div>
+            <div class="flex flex-1 justify-end">
+              <Show when={canManage()}>
+                <Button
+                  type="button"
+                  onClick={() =>
+                    void (activeProgramId()
+                      ? handleDone()
+                      : persistProgramMetadata())
+                  }
+                  disabled={
+                    isSaving() || isMutatingItems() || !hasValidProgramName()
+                  }
+                  variant="default"
+                  size="sm"
+                  data-testid="save-program-button"
+                >
+                  <Show
+                    when={isSaving()}
+                    fallback={
+                      activeProgramId() ? (
+                        <>
+                          <Save size={16} />
+                          Save
+                        </>
+                      ) : (
+                        <>
+                          <Plus size={16} />
+                          Create
+                        </>
+                      )
+                    }
+                  >
+                    Saving...
+                  </Show>
+                </Button>
+              </Show>
+            </div>
+          </header>
+
+          <div class="flex items-start gap-4">
+            <p class="text-sm text-gray-600 dark:text-gray-400">
               Build a musical Program from individual Tunes and eligible Tune
               Sets.
             </p>
           </div>
-
-          <div class="flex items-center gap-3">
-            <Show when={canManage() && activeProgramId()}>
-              <button
-                type="button"
-                class="rounded-md border border-red-200 px-3 py-2 text-sm font-medium text-red-700 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900/70 dark:text-red-300 dark:hover:bg-red-950/40"
-                onClick={() => void handleDeleteProgram()}
-                disabled={isSaving() || isMutatingItems()}
-                data-testid="delete-program-button"
-              >
-                Delete Program
-              </button>
-            </Show>
-
-            <button
-              type="button"
-              onClick={() => void handleDone()}
-              disabled={isSaving() || isMutatingItems()}
-              class="text-sm font-medium text-gray-700 hover:underline disabled:opacity-50 dark:text-gray-300"
-              data-testid="close-program-builder-button"
-            >
-              <span class="inline-flex items-center gap-2">
-                <span>{canManage() ? "Done" : "Close"}</span>
-                <CircleX size={18} />
-              </span>
-            </button>
-
-            <Show when={canManage() && !activeProgramId()}>
-              <button
-                type="button"
-                onClick={() => void persistProgramMetadata()}
-                disabled={isSaving() || isMutatingItems()}
-                class="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-                data-testid="save-program-button"
-              >
-                <Show
-                  when={isSaving()}
-                  fallback={
-                    <>
-                      <span>Create Program</span>
-                      <Save size={16} />
-                    </>
-                  }
-                >
-                  Saving...
-                </Show>
-              </button>
-            </Show>
-          </div>
         </div>
 
-        <div class="grid min-h-0 flex-1 gap-0 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+        <div
+          class={`grid min-h-0 flex-1 gap-0 ${props.forceViewMode ? "lg:grid-cols-1" : "lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]"}`}
+        >
           <section class="min-h-0 border-b border-gray-200 p-4 dark:border-gray-700 lg:border-b-0 lg:border-r sm:p-6">
             <div class="space-y-4">
-              <div class="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-                <div class="space-y-2">
-                  <label
-                    for="program-name"
-                    class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                  >
-                    Program Name
-                  </label>
+              <div class="space-y-4">
+                <div
+                  class={`space-y-2 rounded-lg p-3 ${canManage() && !hasValidProgramName() ? "border border-red-200/70 bg-red-50/40 dark:border-red-900/60 dark:bg-red-950/10" : "border border-transparent bg-transparent"}`}
+                >
+                  <div class="flex items-center gap-2">
+                    <label
+                      for="program-name"
+                      class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      Program Name
+                    </label>
+                    <Show when={canManage() && !hasValidProgramName()}>
+                      <span class="rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-red-700 dark:bg-red-950/60 dark:text-red-300">
+                        Required
+                      </span>
+                    </Show>
+                  </div>
                   <input
                     id="program-name"
+                    ref={programNameInputRef}
+                    autofocus={
+                      props.isOpen && isCreatingProgram() && canManage()
+                    }
                     type="text"
                     value={name()}
                     onInput={(event) => setName(event.currentTarget.value)}
                     disabled={!canManage()}
-                    class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                    required
+                    aria-required="true"
+                    aria-invalid={canManage() && !hasValidProgramName()}
+                    aria-describedby="program-name-help"
+                    class={`w-full rounded-md border bg-white px-3 py-2 text-sm text-gray-900 transition-colors placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/70 focus:border-blue-500 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-400 dark:focus:ring-blue-400/60 dark:focus:border-blue-400 ${canManage() && !hasValidProgramName() ? "border-red-400 ring-1 ring-red-400/40 dark:border-red-500 dark:ring-red-500/30" : "border-gray-300 dark:border-gray-700"}`}
                     placeholder="Festival opener"
                     data-testid="program-name-input"
                   />
+                  <p
+                    id="program-name-help"
+                    class={`text-xs ${canManage() && !hasValidProgramName() ? "text-red-600 dark:text-red-400" : "text-gray-500 dark:text-gray-400"}`}
+                  >
+                    Enter a program name to enable Create and add tunes or tune
+                    sets.
+                  </p>
                 </div>
 
                 <div class="space-y-2">
@@ -588,125 +631,134 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
                   >
                     Notes
                   </label>
-                  <input
+                  <textarea
                     id="program-description"
-                    type="text"
                     value={description()}
                     onInput={(event) =>
                       setDescription(event.currentTarget.value)
                     }
                     disabled={!canManage()}
-                    class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                    rows={3}
+                    class="min-h-24 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
                     placeholder="Optional set notes"
                     data-testid="program-description-input"
                   />
                 </div>
               </div>
 
-              <div class="flex flex-col gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60">
-                <div>
-                  <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Library
-                  </h3>
-                  <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                    Search the existing Tune and Tune Set grid, then add items
-                    to the Program.
-                  </p>
-                </div>
+              <Show when={!props.forceViewMode}>
+                <div class="flex flex-col gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60">
+                  <div>
+                    <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      Library
+                    </h3>
+                    <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                      Search the existing Tune and Tune Set grid, then add items
+                      to the Program.
+                    </p>
+                  </div>
 
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-                  <input
-                    type="text"
-                    value={query()}
-                    onInput={(event) => setQuery(event.currentTarget.value)}
-                    placeholder="Search tunes and tune sets"
-                    class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-                    data-testid="program-candidate-search-input"
-                  />
-                  <div class="flex items-center gap-2">
-                    <button
-                      type="button"
-                      class={`rounded-md px-3 py-2 text-xs font-medium ${candidateFilter() === "all" ? "bg-blue-600 text-white" : "border border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-200"}`}
-                      onClick={() => setCandidateFilter("all")}
-                      data-testid="program-candidate-filter-all"
+                  <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+                    <input
+                      type="text"
+                      value={query()}
+                      onInput={(event) => setQuery(event.currentTarget.value)}
+                      placeholder="Search tunes and tune sets"
+                      class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+                      data-testid="program-candidate-search-input"
+                    />
+                    <div class="flex items-center gap-2">
+                      <button
+                        type="button"
+                        class={`rounded-md px-3 py-2 text-xs font-medium ${candidateFilter() === "all" ? "bg-blue-600 text-white" : "border border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-200"}`}
+                        onClick={() => setCandidateFilter("all")}
+                        data-testid="program-candidate-filter-all"
+                      >
+                        All
+                      </button>
+                      <button
+                        type="button"
+                        class={`rounded-md px-3 py-2 text-xs font-medium ${candidateFilter() === "tune" ? "bg-blue-600 text-white" : "border border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-200"}`}
+                        onClick={() => setCandidateFilter("tune")}
+                        data-testid="program-candidate-filter-tunes"
+                      >
+                        Tunes
+                      </button>
+                      <button
+                        type="button"
+                        class={`rounded-md px-3 py-2 text-xs font-medium ${candidateFilter() === "tune_set" ? "bg-blue-600 text-white" : "border border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-200"}`}
+                        onClick={() => setCandidateFilter("tune_set")}
+                        data-testid="program-candidate-filter-tune-sets"
+                      >
+                        Tune Sets
+                      </button>
+                    </div>
+                  </div>
+
+                  <div
+                    class="min-h-0 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+                    data-testid="program-candidate-list"
+                  >
+                    <Show
+                      when={candidateItems().length > 0}
+                      fallback={
+                        <div class="px-4 py-10 text-sm text-gray-500 dark:text-gray-400">
+                          No matching Tunes or Tune Sets.
+                        </div>
+                      }
                     >
-                      All
-                    </button>
-                    <button
-                      type="button"
-                      class={`rounded-md px-3 py-2 text-xs font-medium ${candidateFilter() === "tune" ? "bg-blue-600 text-white" : "border border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-200"}`}
-                      onClick={() => setCandidateFilter("tune")}
-                      data-testid="program-candidate-filter-tunes"
-                    >
-                      Tunes
-                    </button>
-                    <button
-                      type="button"
-                      class={`rounded-md px-3 py-2 text-xs font-medium ${candidateFilter() === "tune_set" ? "bg-blue-600 text-white" : "border border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-200"}`}
-                      onClick={() => setCandidateFilter("tune_set")}
-                      data-testid="program-candidate-filter-tune-sets"
-                    >
-                      Tune Sets
-                    </button>
+                      <div class="max-h-[48vh] overflow-y-auto">
+                        <For each={candidateItems()}>
+                          {(candidate) => (
+                            <div class="flex items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 last:border-b-0 dark:border-gray-700">
+                              <div class="min-w-0">
+                                <div class="flex items-center gap-2">
+                                  <span class="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                                    {candidate.kind === "tune"
+                                      ? "Tune"
+                                      : "Tune Set"}
+                                  </span>
+                                  <span class="truncate text-sm font-medium text-gray-900 dark:text-white">
+                                    {candidate.title}
+                                  </span>
+                                </div>
+                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                  {candidate.subtitle}
+                                </div>
+                              </div>
+
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  void handleAddCandidate(candidate)
+                                }
+                                disabled={
+                                  !hasValidProgramName() ||
+                                  !canManage() ||
+                                  isMutatingItems() ||
+                                  isSaving()
+                                }
+                                class="inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100 disabled:opacity-50 dark:border-blue-900/70 dark:bg-blue-950/30 dark:text-blue-200"
+                                data-testid="program-add-candidate-button"
+                              >
+                                <Plus size={14} />
+                                Add
+                              </button>
+                            </div>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
                   </div>
                 </div>
-
-                <div
-                  class="min-h-0 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
-                  data-testid="program-candidate-list"
-                >
-                  <Show
-                    when={candidateItems().length > 0}
-                    fallback={
-                      <div class="px-4 py-10 text-sm text-gray-500 dark:text-gray-400">
-                        No matching Tunes or Tune Sets.
-                      </div>
-                    }
-                  >
-                    <div class="max-h-[48vh] overflow-y-auto">
-                      <For each={candidateItems()}>
-                        {(candidate) => (
-                          <div class="flex items-start justify-between gap-3 border-b border-gray-200 px-4 py-3 last:border-b-0 dark:border-gray-700">
-                            <div class="min-w-0">
-                              <div class="flex items-center gap-2">
-                                <span class="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-gray-600 dark:bg-gray-800 dark:text-gray-300">
-                                  {candidate.kind === "tune"
-                                    ? "Tune"
-                                    : "Tune Set"}
-                                </span>
-                                <span class="truncate text-sm font-medium text-gray-900 dark:text-white">
-                                  {candidate.title}
-                                </span>
-                              </div>
-                              <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                                {candidate.subtitle}
-                              </div>
-                            </div>
-
-                            <button
-                              type="button"
-                              onClick={() => void handleAddCandidate(candidate)}
-                              disabled={
-                                !canManage() || isMutatingItems() || isSaving()
-                              }
-                              class="inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100 disabled:opacity-50 dark:border-blue-900/70 dark:bg-blue-950/30 dark:text-blue-200"
-                              data-testid="program-add-candidate-button"
-                            >
-                              <Plus size={14} />
-                              Add
-                            </button>
-                          </div>
-                        )}
-                      </For>
-                    </div>
-                  </Show>
-                </div>
-              </div>
+              </Show>
             </div>
           </section>
 
-          <section class="min-h-0 p-4 sm:p-6">
-            <div class="flex h-full min-h-0 flex-col rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60">
+          <section
+            class={`flex min-h-0 h-full flex-col p-4 sm:p-6 ${props.forceViewMode ? "lg:border-l border-gray-200 dark:border-gray-700" : ""}`}
+          >
+            <div class="flex h-full min-h-0 flex-1 flex-col rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/60">
               <div class="mb-4 flex items-start justify-between gap-4">
                 <div>
                   <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
@@ -724,13 +776,13 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
               </div>
 
               <div
-                class="min-h-0 flex-1 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+                class="flex min-h-0 flex-1 flex-col rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
                 data-testid="program-items-list"
               >
                 <Show
                   when={activeProgramId()}
                   fallback={
-                    <div class="px-4 py-10 text-sm text-gray-500 dark:text-gray-400">
+                    <div class="flex min-h-0 flex-1 px-4 py-10 text-sm text-gray-500 dark:text-gray-400">
                       Save the Program name first, then add Tunes or Tune Sets
                       on the left.
                     </div>
@@ -739,9 +791,18 @@ export const ProgramBuilderDialog: Component<ProgramBuilderDialogProps> = (
                   <Show
                     when={(programItems() ?? []).length > 0}
                     fallback={
-                      <div class="px-4 py-10 text-sm text-gray-500 dark:text-gray-400">
-                        This Program is empty. Add Tunes or Tune Sets from the
-                        left pane.
+                      <div class="flex min-h-0 flex-1 px-4 py-10 text-sm text-gray-500 dark:text-gray-400">
+                        <Show
+                          when={props.forceViewMode}
+                          fallback={
+                            <>
+                              This Program is empty. Add Tunes or Tune Sets from
+                              the left pane.
+                            </>
+                          }
+                        >
+                          This Program is empty.
+                        </Show>
                       </div>
                     }
                   >

--- a/src/components/import/AddTuneDialog.tsx
+++ b/src/components/import/AddTuneDialog.tsx
@@ -12,7 +12,7 @@
 
 import { useLocation, useNavigate } from "@solidjs/router";
 import abcjs from "abcjs";
-import { Import } from "lucide-solid";
+import { Import, Plus, Search } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createEffect, createSignal, Show } from "solid-js";
 import { useAuth } from "@/lib/auth/AuthContext";
@@ -38,11 +38,8 @@ import type {
 } from "../../lib/import/the-session-schemas";
 import {
   AlertDialog,
-  AlertDialogCloseButton,
   AlertDialogContent,
   AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "../ui/alert-dialog";
@@ -497,13 +494,49 @@ export const AddTuneDialog: Component<AddTuneDialogProps> = (props) => {
           class="max-w-3xl bg-white dark:bg-gray-900"
           data-testid="add-tune-dialog"
         >
-          <AlertDialogCloseButton />
-          <AlertDialogHeader>
-            <AlertDialogTitle>Add Tune</AlertDialogTitle>
-            <AlertDialogDescription>
-              Add or Import a tune.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+          <header class="flex justify-between items-center w-full mb-4">
+            <div class="flex flex-1 justify-start">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setMainDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+            <div class="flex min-w-0 flex-1 justify-center px-3">
+              <AlertDialogTitle class="text-center">Add Tune</AlertDialogTitle>
+            </div>
+            <div class="flex flex-1 justify-end gap-2">
+              <Button variant="outline" size="sm" onClick={handleNew}>
+                <Plus class="h-4 w-4" />
+                Create
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleSearchOrImport}
+                disabled={
+                  !urlOrTitle() || selectedGenre() !== "ITRAD" || isImporting()
+                }
+              >
+                {isImporting() ? (
+                  "Importing..."
+                ) : hasHttpProtocol(urlOrTitle()) ? (
+                  <>
+                    <Import class="h-4 w-4" />
+                    Import
+                  </>
+                ) : (
+                  <>
+                    <Search class="h-4 w-4" />
+                    Search
+                  </>
+                )}
+              </Button>
+            </div>
+          </header>
+
+          <AlertDialogDescription>Add or import a tune.</AlertDialogDescription>
 
           {/* Genre Selection */}
           <div class="grid grid-cols-4 items-center gap-4">
@@ -688,24 +721,6 @@ export const AddTuneDialog: Component<AddTuneDialogProps> = (props) => {
               {importError()}
             </div>
           </Show>
-
-          <AlertDialogFooter>
-            <Button variant="outline" onClick={handleNew}>
-              New
-            </Button>
-            <Button
-              onClick={handleSearchOrImport}
-              disabled={
-                !urlOrTitle() || selectedGenre() !== "ITRAD" || isImporting()
-              }
-            >
-              {isImporting()
-                ? "Importing..."
-                : hasHttpProtocol(urlOrTitle())
-                  ? "Import"
-                  : "Search"}
-            </Button>
-          </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
 

--- a/src/components/import/AddTuneDialog.tsx
+++ b/src/components/import/AddTuneDialog.tsx
@@ -510,7 +510,7 @@ export const AddTuneDialog: Component<AddTuneDialogProps> = (props) => {
             <div class="flex flex-1 justify-end gap-2">
               <Button variant="outline" size="sm" onClick={handleNew}>
                 <Plus class="h-4 w-4" />
-                Create
+                New
               </Button>
               <Button
                 size="sm"

--- a/src/components/import/SelectSettingDialog.tsx
+++ b/src/components/import/SelectSettingDialog.tsx
@@ -8,15 +8,13 @@
  */
 
 import abcjs from "abcjs";
+import { Check } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createEffect, createSignal, For, onCleanup } from "solid-js";
 import {
   AlertDialog,
-  AlertDialogCloseButton,
   AlertDialogContent,
   AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
   AlertDialogTitle,
 } from "../ui/alert-dialog";
 import { Button } from "../ui/button";
@@ -176,14 +174,33 @@ export const SelectSettingDialog: Component<SelectSettingDialogProps> = (
   return (
     <AlertDialog open={props.open} onOpenChange={props.onOpenChange}>
       <AlertDialogContent class="max-w-3xl bg-gray-900 dark:bg-gray-900">
-        <AlertDialogCloseButton />
-        <AlertDialogHeader>
-          <AlertDialogTitle>Select a Setting</AlertDialogTitle>
-          <AlertDialogDescription>
-            Please select the setting incipit that you would like to use. You
-            may edit the incipit later.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+        <header class="flex justify-between items-center w-full mb-4">
+          <div class="flex flex-1 justify-start">
+            <Button variant="outline" size="sm" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </div>
+          <div class="flex min-w-0 flex-1 justify-center px-3">
+            <AlertDialogTitle class="text-center">
+              Select a Setting
+            </AlertDialogTitle>
+          </div>
+          <div class="flex flex-1 justify-end">
+            <Button
+              onClick={handleSelectSetting}
+              disabled={selectedIndex() === null}
+              size="sm"
+            >
+              <Check class="h-4 w-4" />
+              Select
+            </Button>
+          </div>
+        </header>
+
+        <AlertDialogDescription>
+          Please select the setting incipit that you would like to use. You may
+          edit the incipit later.
+        </AlertDialogDescription>
 
         {/* Settings List with ABC Previews */}
         <div class="max-h-96 overflow-y-auto space-y-2">
@@ -198,18 +215,6 @@ export const SelectSettingDialog: Component<SelectSettingDialogProps> = (
             )}
           </For>
         </div>
-
-        <AlertDialogFooter>
-          <Button variant="outline" onClick={handleCancel}>
-            Cancel
-          </Button>
-          <Button
-            onClick={handleSelectSetting}
-            disabled={selectedIndex() === null}
-          >
-            Select Setting
-          </Button>
-        </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
   );

--- a/src/components/import/SelectTuneDialog.tsx
+++ b/src/components/import/SelectTuneDialog.tsx
@@ -7,17 +7,14 @@
  * @module components/import/SelectTuneDialog
  */
 
-import { ExternalLink } from "lucide-solid";
+import { ExternalLink, Import } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createSignal, For } from "solid-js";
 import type { ITheSessionTuneSummary } from "../../lib/import/the-session-schemas";
 import {
   AlertDialog,
-  AlertDialogCloseButton,
   AlertDialogContent,
   AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
   AlertDialogTitle,
 } from "../ui/alert-dialog";
 import { Button } from "../ui/button";
@@ -56,13 +53,28 @@ export const SelectTuneDialog: Component<SelectTuneDialogProps> = (props) => {
   return (
     <AlertDialog open={props.open} onOpenChange={props.onOpenChange}>
       <AlertDialogContent class="max-w-2xl bg-gray-900 dark:bg-gray-900">
-        <AlertDialogCloseButton />
-        <AlertDialogHeader>
-          <AlertDialogTitle>Select a Tune from thesession.org</AlertDialogTitle>
-          <AlertDialogDescription>
-            Please select the tune that best matches your search.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+        <header class="flex justify-between items-center w-full mb-4">
+          <div class="flex flex-1 justify-start">
+            <Button variant="outline" size="sm" onClick={handleCancel}>
+              Cancel
+            </Button>
+          </div>
+          <div class="flex min-w-0 flex-1 justify-center px-3">
+            <AlertDialogTitle class="text-center">
+              Select a Tune from thesession.org
+            </AlertDialogTitle>
+          </div>
+          <div class="flex flex-1 justify-end">
+            <Button onClick={handleImport} disabled={!selectedUrl()} size="sm">
+              <Import class="h-4 w-4" />
+              Import
+            </Button>
+          </div>
+        </header>
+
+        <AlertDialogDescription>
+          Please select the tune that best matches your search.
+        </AlertDialogDescription>
 
         {/* Tune List with Radio Buttons */}
         <div class="max-h-96 overflow-y-auto space-y-2">
@@ -98,15 +110,6 @@ export const SelectTuneDialog: Component<SelectTuneDialogProps> = (props) => {
             )}
           </For>
         </div>
-
-        <AlertDialogFooter>
-          <Button variant="outline" onClick={handleCancel}>
-            Cancel
-          </Button>
-          <Button onClick={handleImport} disabled={!selectedUrl()}>
-            Import
-          </Button>
-        </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
   );

--- a/src/components/layout/ThemeSwitcher.tsx
+++ b/src/components/layout/ThemeSwitcher.tsx
@@ -7,6 +7,7 @@
  * @module components/layout/ThemeSwitcher
  */
 
+import { Monitor, Moon, Sun } from "lucide-solid";
 import { type Component, createEffect, createSignal, onMount } from "solid-js";
 
 type ThemeMode = "light" | "dark" | "system";
@@ -88,50 +89,11 @@ export const ThemeSwitcher: Component<ThemeSwitcherProps> = (props) => {
   const getIcon = () => {
     const currentMode = mode();
     if (currentMode === "light") {
-      return (
-        <svg
-          class="w-5 h-5"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          aria-hidden="true"
-        >
-          <title>Light mode</title>
-          <path
-            fill-rule="evenodd"
-            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-            clip-rule="evenodd"
-          />
-        </svg>
-      );
+      return <Sun class="w-5 h-5" aria-hidden="true" />;
     } else if (currentMode === "dark") {
-      return (
-        <svg
-          class="w-5 h-5"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          aria-hidden="true"
-        >
-          <title>Dark mode</title>
-          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-        </svg>
-      );
+      return <Moon class="w-5 h-5" aria-hidden="true" />;
     } else {
-      // System mode - show computer/monitor icon
-      return (
-        <svg
-          class="w-5 h-5"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          aria-hidden="true"
-        >
-          <title>System mode</title>
-          <path
-            fill-rule="evenodd"
-            d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z"
-            clip-rule="evenodd"
-          />
-        </svg>
-      );
+      return <Monitor class="w-5 h-5" aria-hidden="true" />;
     }
   };
 

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -8,7 +8,25 @@
  */
 
 import { useLocation } from "@solidjs/router";
-import { MessageCircle } from "lucide-solid";
+import {
+  Bug,
+  Check,
+  ChevronDown,
+  Database,
+  Download,
+  FileText,
+  Home,
+  Info,
+  LogOut,
+  MessageCircle,
+  Settings,
+  Shield,
+  Tag,
+  Trash2,
+  Upload,
+  UserPlus,
+  Users,
+} from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -319,21 +337,11 @@ const LogoDropdown: Component<{
         <span class="hidden sm:inline ml-[0ch] text-lg dark:text-blue-400">
           TuneTrees
         </span>
-        <svg
+        <ChevronDown
           class="w-4 h-4 transition-transform"
           classList={{ "rotate-180": showDropdown() }}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
           aria-hidden="true"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+        />
       </button>
 
       {/* Dropdown Menu */}
@@ -346,20 +354,7 @@ const LogoDropdown: Component<{
               class="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2"
               onClick={() => setShowDropdown(false)}
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-                />
-              </svg>
+              <Home class="w-4 h-4" aria-hidden="true" />
               Home
             </a>
 
@@ -373,20 +368,7 @@ const LogoDropdown: Component<{
               onClick={handleAboutClick}
               data-testid="logo-dropdown-about-button"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <Info class="w-4 h-4" aria-hidden="true" />
               About TuneTrees...
             </button>
 
@@ -399,20 +381,7 @@ const LogoDropdown: Component<{
               onClick={() => setShowDropdown(false)}
               data-testid="logo-dropdown-whats-new-link"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z"
-                />
-              </svg>
+              <Tag class="w-4 h-4" aria-hidden="true" />
               What's New
             </a>
 
@@ -426,20 +395,7 @@ const LogoDropdown: Component<{
               onClick={() => setShowDropdown(false)}
               data-testid="logo-dropdown-privacy-link"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 11c1.105 0 2-.895 2-2s-.895-2-2-2-2 .895-2 2 .895 2 2 2zm7 6a7 7 0 10-14 0v1h14v-1z"
-                />
-              </svg>
+              <Shield class="w-4 h-4" aria-hidden="true" />
               Privacy Policy
             </a>
 
@@ -450,20 +406,7 @@ const LogoDropdown: Component<{
               onClick={() => setShowDropdown(false)}
               data-testid="logo-dropdown-terms-link"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M9 12h6m-6 4h6m2 4H7a2 2 0 01-2-2V4a2 2 0 012-2h6l4 4v12a2 2 0 01-2 2z"
-                />
-              </svg>
+              <FileText class="w-4 h-4" aria-hidden="true" />
               Terms of Service
             </a>
           </div>
@@ -683,21 +626,11 @@ const RepertoireDropdown: Component<{
             ? getRepertoireDisplayName(selectedRepertoire()!)
             : "No Repertoire"}
         </span>
-        <svg
+        <ChevronDown
           class="w-4 h-4 transition-transform"
           classList={{ "rotate-180": showDropdown() }}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
           aria-hidden="true"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+        />
       </button>
 
       {/* Dropdown Menu */}
@@ -740,18 +673,10 @@ const RepertoireDropdown: Component<{
                     <Show
                       when={currentRepertoireId() === repertoire.repertoireId}
                     >
-                      <svg
+                      <Check
                         class="w-4 h-4 text-blue-600 dark:text-blue-400"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
                         aria-hidden="true"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clip-rule="evenodd"
-                        />
-                      </svg>
+                      />
                     </Show>
                   </button>
                 )}
@@ -768,26 +693,7 @@ const RepertoireDropdown: Component<{
               onClick={handleManageRepertoires}
               data-testid="manage-repertoires-button"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                />
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
+              <Settings class="w-4 h-4" aria-hidden="true" />
               Configure Repertoires...
             </button>
           </div>
@@ -1065,21 +971,11 @@ export const TopNav: Component = () => {
                       </>
                     )}
                   </Show>
-                  <svg
+                  <ChevronDown
                     class="w-4 h-4 transition-transform"
                     classList={{ "rotate-180": showUserMenu() }}
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
                     aria-hidden="true"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
+                  />
                 </button>
 
                 {/* Dropdown Menu */}
@@ -1185,20 +1081,7 @@ export const TopNav: Component = () => {
                           }}
                           data-testid="create-account-button"
                         >
-                          <svg
-                            class="w-4 h-4"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                            aria-hidden="true"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
-                            />
-                          </svg>
+                          <UserPlus class="w-4 h-4" aria-hidden="true" />
                           Create Account
                         </button>
                       </Show>
@@ -1213,26 +1096,7 @@ export const TopNav: Component = () => {
                         }}
                         data-testid="user-settings-button"
                       >
-                        <svg
-                          class="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                          />
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                          />
-                        </svg>
+                        <Settings class="w-4 h-4" aria-hidden="true" />
                         User Settings
                       </button>
 
@@ -1245,20 +1109,7 @@ export const TopNav: Component = () => {
                         }}
                         data-testid="user-menu-groups-link"
                       >
-                        <svg
-                          class="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M17 20h5V18a4 4 0 00-4-4h-1m-4 6H2v-2a4 4 0 014-4h7a4 4 0 014 4v2zM9.5 10a4 4 0 100-8 4 4 0 000 8zm8 1a3 3 0 100-6 3 3 0 000 6z"
-                          />
-                        </svg>
+                        <Users class="w-4 h-4" aria-hidden="true" />
                         Groups
                       </button>
 
@@ -1276,20 +1127,7 @@ export const TopNav: Component = () => {
                           window.location.href = "/login";
                         }}
                       >
-                        <svg
-                          class="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-                          />
-                        </svg>
+                        <LogOut class="w-4 h-4" aria-hidden="true" />
                         Sign Out
                       </button>
                     </div>
@@ -1313,21 +1151,7 @@ export const TopNav: Component = () => {
                 data-testid="database-status-button"
               >
                 {/* Database Icon */}
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="w-5 h-5"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <ellipse cx="12" cy="5" rx="9" ry="3" />
-                  <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
-                  <path d="M3 12c0 1.66 4 3 9 3s9-1.34 9-3" />
-                </svg>
+                <Database class="w-5 h-5" aria-hidden="true" />
 
                 {/* Status indicator badge */}
                 <Show
@@ -1474,21 +1298,7 @@ export const TopNav: Component = () => {
                             !isOnline() || forceSyncUpBusy(),
                         }}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          class="w-4 h-4"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          aria-hidden="true"
-                        >
-                          <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-                          <polyline points="17 8 12 3 7 8" />
-                          <line x1="12" y1="3" x2="12" y2="15" />
-                        </svg>
+                        <Upload class="w-4 h-4" aria-hidden="true" />
                         Force Sync Up
                         {!isOnline() && (
                           <span class="ml-auto text-xs text-gray-500 dark:text-gray-400">
@@ -1560,23 +1370,7 @@ export const TopNav: Component = () => {
                           }}
                           data-testid="force-clean-local-reset-button"
                         >
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="w-4 h-4"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            aria-hidden="true"
-                          >
-                            <path d="M3 6h18" />
-                            <path d="M8 6V4a1 1 0 011-1h6a1 1 0 011 1v2" />
-                            <path d="M19 6v13a2 2 0 01-2 2H7a2 2 0 01-2-2V6" />
-                            <path d="M10 11v6" />
-                            <path d="M14 11v6" />
-                          </svg>
+                          <Trash2 class="w-4 h-4" aria-hidden="true" />
                           Force Clean Local Reset
                           {!isOnline() && (
                             <span class="ml-auto text-xs text-gray-500 dark:text-gray-400">
@@ -1621,21 +1415,7 @@ export const TopNav: Component = () => {
                           "opacity-50 cursor-not-allowed": !isOnline(),
                         }}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          class="w-4 h-4"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          aria-hidden="true"
-                        >
-                          <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
-                          <polyline points="7 10 12 15 17 10" />
-                          <line x1="12" y1="15" x2="12" y2="3" />
-                        </svg>
+                        <Download class="w-4 h-4" aria-hidden="true" />
                         Force Full Sync Down
                         {!isOnline() && (
                           <span class="ml-auto text-xs text-gray-500 dark:text-gray-400">
@@ -1654,19 +1434,7 @@ export const TopNav: Component = () => {
                         class="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors flex items-center gap-2"
                         onClick={() => setShowDbMenu(false)}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          class="w-4 h-4"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          aria-hidden="true"
-                        >
-                          <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                        </svg>
+                        <Bug class="w-4 h-4" aria-hidden="true" />
                         Database Browser (Dev)
                       </a>
                     </Show>

--- a/src/components/layout/UserSettingsDialog.tsx
+++ b/src/components/layout/UserSettingsDialog.tsx
@@ -15,6 +15,7 @@
  * @module components/layout/UserSettingsDialog
  */
 
+import { Menu, X } from "lucide-solid";
 import {
   type Component,
   createSignal,
@@ -29,7 +30,6 @@ import {
   useUserSettingsDialog,
 } from "@/contexts/UserSettingsDialogContext";
 
-// Lazy-load each settings page to keep the initial bundle small.
 const AppearancePage = lazy(() => import("@/routes/user-settings/appearance"));
 const CatalogSyncPage = lazy(
   () => import("@/routes/user-settings/catalog-sync")
@@ -96,10 +96,6 @@ const TabContent: Component<{ tab: UserSettingsTab }> = (props) => (
   </Suspense>
 );
 
-/**
- * Renders the floating settings overlay.  Mount once in App.tsx outside the
- * Router so it overlays any route without unmounting the current page.
- */
 export const UserSettingsDialog: Component = () => {
   const { isOpen, currentTab, closeUserSettings, navigateToTab } =
     useUserSettingsDialog();
@@ -111,12 +107,11 @@ export const UserSettingsDialog: Component = () => {
 
   const handleTabClick = (tab: UserSettingsTab) => {
     navigateToTab(tab);
-    setIsSidebarOpen(false); // close mobile sidebar after selection
+    setIsSidebarOpen(false);
   };
 
   return (
     <Show when={isOpen()}>
-      {/* Modal Backdrop */}
       <button
         type="button"
         class="fixed inset-0 bg-black/50 z-40"
@@ -126,7 +121,6 @@ export const UserSettingsDialog: Component = () => {
         data-testid="settings-modal-backdrop"
       />
 
-      {/* Modal Dialog */}
       <div
         class="fixed inset-0 z-50 flex items-start justify-center pt-2 md:pt-8 pb-2 md:pb-16 pointer-events-none"
         data-testid="settings-modal-wrapper"
@@ -140,10 +134,8 @@ export const UserSettingsDialog: Component = () => {
           aria-modal="true"
           data-testid="settings-modal"
         >
-          {/* Header */}
           <div class="px-4 md:px-6 py-3 md:py-4 border-b border-gray-200 dark:border-gray-700 flex items-start justify-between shrink-0">
             <div class="flex items-center gap-3">
-              {/* Mobile Menu Toggle */}
               <button
                 type="button"
                 onClick={() => setIsSidebarOpen(!isSidebarOpen())}
@@ -151,20 +143,7 @@ export const UserSettingsDialog: Component = () => {
                 aria-label="Toggle menu"
                 data-testid="settings-menu-toggle"
               >
-                <svg
-                  class="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <title>Menu</title>
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
-                </svg>
+                <Menu class="w-5 h-5" aria-hidden="true" />
               </button>
 
               <div>
@@ -187,27 +166,11 @@ export const UserSettingsDialog: Component = () => {
               aria-label="Close settings"
               data-testid="settings-close-button"
             >
-              <svg
-                class="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-label="Close icon"
-              >
-                <title>Close</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <X class="w-5 h-5" aria-hidden="true" />
             </button>
           </div>
 
-          {/* Body */}
           <div class="flex-1 flex min-h-0 overflow-hidden relative">
-            {/* Mobile Sidebar Overlay */}
             <Show when={isSidebarOpen()}>
               <button
                 type="button"
@@ -217,7 +180,6 @@ export const UserSettingsDialog: Component = () => {
               />
             </Show>
 
-            {/* Sidebar */}
             <aside
               class="absolute md:relative z-20 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 overflow-y-auto p-4 h-full transition-transform md:transition-none"
               classList={{
@@ -247,7 +209,6 @@ export const UserSettingsDialog: Component = () => {
               </nav>
             </aside>
 
-            {/* Content Area */}
             <main
               class="flex-1 overflow-y-auto p-4 md:p-6 w-full"
               data-testid="settings-content"

--- a/src/components/onboarding/OnboardingOverlay.tsx
+++ b/src/components/onboarding/OnboardingOverlay.tsx
@@ -32,6 +32,7 @@ import {
 } from "../../lib/services/repertoire-service";
 import { getPracticeDate } from "../../lib/utils/practice-date";
 import { type Genre, GenreMultiSelect } from "../genre-selection";
+import { Button } from "../ui/button";
 
 /**
  * Onboarding Overlay Component
@@ -393,29 +394,31 @@ export const OnboardingOverlay: Component = () => {
                   </Show>
                 </div>
 
-                <div class="shrink-0 border-t border-gray-200 dark:border-gray-700 px-6 py-4 bg-white dark:bg-gray-800">
-                  <div class="flex gap-3">
-                    <button
+                <div class="shrink-0 border-t border-gray-200 bg-white px-6 py-4 dark:border-gray-700 dark:bg-gray-800">
+                  <div class="flex w-full justify-between gap-3">
+                    <Button
                       type="button"
                       onClick={handleCancel}
                       disabled={isSavingGenres()}
-                      class="flex-1 min-h-11 py-2 px-4 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      variant="outline"
+                      class="min-h-11"
                       data-testid="onboarding-genre-cancel"
                     >
                       Cancel
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       type="button"
                       onClick={handleSaveGenres}
                       disabled={
                         isSavingGenres() ||
                         effectiveSelectedGenreIds().length === 0
                       }
-                      class="flex-1 min-h-11 py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      variant="default"
+                      class="min-h-11"
                       data-testid="onboarding-genre-continue"
                     >
                       {isSavingGenres() ? "Saving..." : "Continue"}
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </div>

--- a/src/components/practice/AddTunesDialog.tsx
+++ b/src/components/practice/AddTunesDialog.tsx
@@ -7,7 +7,7 @@
  * @module components/practice/AddTunesDialog
  */
 
-import { X } from "lucide-solid";
+import { Plus } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createSignal, Show } from "solid-js";
 import { Button } from "@/components/ui/button";
@@ -57,20 +57,24 @@ export const AddTunesDialog: Component<AddTunesDialogProps> = (props) => {
           aria-modal="true"
         >
           {/* Header */}
-          <div class="flex items-center justify-between mb-4">
-            <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
-              Add More Tunes
-            </h2>
-            <Button
-              type="button"
-              onClick={props.onClose}
-              variant="ghost"
-              size="icon"
-              aria-label="Close dialog"
-            >
-              <X size={20} />
-            </Button>
-          </div>
+          <header class="flex justify-between items-center w-full mb-4">
+            <div class="flex flex-1 justify-start">
+              <Button type="button" onClick={props.onClose} variant="outline">
+                Cancel
+              </Button>
+            </div>
+            <div class="flex min-w-0 flex-1 justify-center px-3">
+              <h2 class="text-center text-xl font-semibold text-gray-900 dark:text-gray-100">
+                Add More Tunes
+              </h2>
+            </div>
+            <div class="flex flex-1 justify-end">
+              <Button type="button" onClick={handleConfirm} variant="default">
+                <Plus size={16} />
+                Add
+              </Button>
+            </div>
+          </header>
 
           {/* Content */}
           <div class="mb-6">
@@ -95,16 +99,6 @@ export const AddTunesDialog: Component<AddTunesDialogProps> = (props) => {
                 autofocus
               />
             </label>
-          </div>
-
-          {/* Actions */}
-          <div class="flex w-full items-center justify-between gap-3">
-            <Button type="button" onClick={props.onClose} variant="outline">
-              Cancel
-            </Button>
-            <Button type="button" onClick={handleConfirm} variant="default">
-              Add
-            </Button>
           </div>
         </div>
       </div>

--- a/src/components/practice/AddTunesDialog.tsx
+++ b/src/components/practice/AddTunesDialog.tsx
@@ -10,6 +10,7 @@
 import { X } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createSignal, Show } from "solid-js";
+import { Button } from "@/components/ui/button";
 
 export interface AddTunesDialogProps {
   /** Whether dialog is open */
@@ -60,14 +61,15 @@ export const AddTunesDialog: Component<AddTunesDialogProps> = (props) => {
             <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">
               Add More Tunes
             </h2>
-            <button
+            <Button
               type="button"
               onClick={props.onClose}
-              class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              variant="ghost"
+              size="icon"
               aria-label="Close dialog"
             >
               <X size={20} />
-            </button>
+            </Button>
           </div>
 
           {/* Content */}
@@ -96,21 +98,13 @@ export const AddTunesDialog: Component<AddTunesDialogProps> = (props) => {
           </div>
 
           {/* Actions */}
-          <div class="flex items-center justify-end gap-3">
-            <button
-              type="button"
-              onClick={props.onClose}
-              class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-            >
+          <div class="flex w-full items-center justify-between gap-3">
+            <Button type="button" onClick={props.onClose} variant="outline">
               Cancel
-            </button>
-            <button
-              type="button"
-              onClick={handleConfirm}
-              class="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors"
-            >
+            </Button>
+            <Button type="button" onClick={handleConfirm} variant="default">
               Add
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/practice/PracticeControlBanner.tsx
+++ b/src/components/practice/PracticeControlBanner.tsx
@@ -19,6 +19,8 @@
 import { DropdownMenu } from "@kobalte/core/dropdown-menu";
 import type { Table } from "@tanstack/solid-table";
 import {
+  Calendar,
+  ChevronDown,
   ChevronRight,
   Columns,
   EllipsisVertical,
@@ -560,20 +562,7 @@ export const PracticeControlBanner: Component<PracticeControlBannerProps> = (
                     : TOOLBAR_BUTTON_NEUTRAL
                 }`}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 7h16M7 12h10M10 17h4"
-                  />
-                </svg>
+                <Plus class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Tune Set</span>
               </button>
 
@@ -583,35 +572,9 @@ export const PracticeControlBanner: Component<PracticeControlBannerProps> = (
                 title="Select practice queue date"
                 class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_NEUTRAL}`}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
+                <Calendar class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>{formatQueueDate(props.queueDate || new Date())}</span>
-                <svg
-                  class="w-3 h-3"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
+                <ChevronDown class="w-3 h-3" aria-hidden="true" />
               </button>
 
               {/* Flashcard Mode toggle - Switch component */}
@@ -653,20 +616,7 @@ export const PracticeControlBanner: Component<PracticeControlBannerProps> = (
                 <span>
                   {props.flashcardMode ? "Fields" : "Display Options"}
                 </span>
-                <svg
-                  class="w-3.5 h-3.5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
+                <ChevronDown class="w-3.5 h-3.5" aria-hidden="true" />
               </button>
             </div>
           </div>

--- a/src/components/practice/QueueDateSelector.tsx
+++ b/src/components/practice/QueueDateSelector.tsx
@@ -10,7 +10,7 @@
  * @module components/practice/QueueDateSelector
  */
 
-import { X } from "lucide-solid";
+import { Grip, X } from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -534,20 +534,7 @@ export const QueueDateSelector: Component<QueueDateSelectorProps> = (props) => {
               aria-label="Resize dialog"
               title="Resize dialog"
             >
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M9 15l6-6M13 19l6-6"
-                />
-              </svg>
+              <Grip class="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/src/components/pwa/OfflineIndicator.tsx
+++ b/src/components/pwa/OfflineIndicator.tsx
@@ -11,6 +11,7 @@
  * - Offline + Pending: Orange banner with pending count
  */
 
+import { Loader2, WifiOff, X } from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -151,45 +152,14 @@ export const OfflineIndicator: Component = () => {
         <div class="px-4 py-3 flex items-center gap-3">
           {/* Status Icon */}
           <Show when={bannerVariant() === "syncing"}>
-            <svg
+            <Loader2
               class="animate-spin h-5 w-5 flex-shrink-0"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <title>Syncing</title>
-              <circle
-                class="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                stroke-width="4"
-              />
-              <path
-                class="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
+              aria-hidden="true"
+            />
           </Show>
 
           <Show when={!isOnline()}>
-            <svg
-              class="h-5 w-5 flex-shrink-0"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <title>Offline</title>
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3m8.293 8.293l1.414 1.414"
-              />
-            </svg>
+            <WifiOff class="h-5 w-5 flex-shrink-0" aria-hidden="true" />
           </Show>
 
           {/* Message */}
@@ -202,21 +172,7 @@ export const OfflineIndicator: Component = () => {
             class="p-1 rounded-md hover:bg-black/10 dark:hover:bg-white/10 transition-colors flex-shrink-0"
             aria-label="Dismiss notification"
           >
-            <svg
-              class="h-4 w-4"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <title>Close</title>
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+            <X class="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
       </div>

--- a/src/components/references/ReferenceForm.tsx
+++ b/src/components/references/ReferenceForm.tsx
@@ -340,13 +340,8 @@ export const ReferenceForm: Component<ReferenceFormProps> = (props) => {
       class="space-y-4"
       data-testid="reference-form"
     >
-      <div class="mb-1 flex w-full items-center justify-between gap-3">
-        <span
-          class={`${fontClasses().text} font-semibold text-gray-700 dark:text-gray-300`}
-        >
-          {heading()}
-        </span>
-        <div class="ml-auto flex items-center gap-2">
+      <header class="flex justify-between items-center w-full mb-4">
+        <div class="flex flex-1 justify-start">
           <Button
             type="button"
             onClick={props.onCancel}
@@ -357,6 +352,15 @@ export const ReferenceForm: Component<ReferenceFormProps> = (props) => {
           >
             Cancel
           </Button>
+        </div>
+        <div class="flex min-w-0 flex-1 justify-center px-3">
+          <span
+            class={`${fontClasses().text} text-center font-semibold text-gray-700 dark:text-gray-300`}
+          >
+            {heading()}
+          </span>
+        </div>
+        <div class="flex flex-1 justify-end">
           <Button
             type="submit"
             disabled={!canSubmit()}
@@ -368,7 +372,7 @@ export const ReferenceForm: Component<ReferenceFormProps> = (props) => {
             Save
           </Button>
         </div>
-      </div>
+      </header>
 
       {/* Type Dropdown */}
       <div>

--- a/src/components/references/ReferenceForm.tsx
+++ b/src/components/references/ReferenceForm.tsx
@@ -7,9 +7,10 @@
  * @module components/references/ReferenceForm
  */
 
-import { Save, X } from "lucide-solid";
+import { Save } from "lucide-solid";
 import { type Component, createEffect, createSignal, Show } from "solid-js";
 import { toast } from "solid-sonner";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -339,31 +340,33 @@ export const ReferenceForm: Component<ReferenceFormProps> = (props) => {
       class="space-y-4"
       data-testid="reference-form"
     >
-      <div class="flex items-center justify-between mb-1">
+      <div class="mb-1 flex w-full items-center justify-between gap-3">
         <span
           class={`${fontClasses().text} font-semibold text-gray-700 dark:text-gray-300`}
         >
           {heading()}
         </span>
-        <div class="flex gap-1.5">
-          <button
+        <div class="ml-auto flex items-center gap-2">
+          <Button
             type="button"
             onClick={props.onCancel}
-            class={`inline-flex items-center gap-0.5 ${fontClasses().textSmall} px-1.5 py-0.5 text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-sm transition-colors border border-gray-200/50 dark:border-gray-700/50 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2`}
+            variant="outline"
+            size="sm"
+            class={fontClasses().textSmall}
             data-testid="reference-cancel-button"
           >
             Cancel
-            <X class={fontClasses().iconSmall} />
-          </button>
-          <button
+          </Button>
+          <Button
             type="submit"
             disabled={!canSubmit()}
-            class={`inline-flex items-center gap-0.5 ${fontClasses().textSmall} px-1.5 py-0.5 text-green-700 dark:text-green-400 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-sm transition-colors border border-gray-200/50 dark:border-gray-700/50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2`}
+            size="sm"
+            class={fontClasses().textSmall}
             data-testid="reference-submit-button"
           >
-            Save
             <Save class={fontClasses().iconSmall} />
-          </button>
+            Save
+          </Button>
         </div>
       </div>
 

--- a/src/components/references/ReferenceList.tsx
+++ b/src/components/references/ReferenceList.tsx
@@ -9,6 +9,7 @@
 
 import { GripVertical, SquarePen, Trash2 } from "lucide-solid";
 import { type Component, createSignal, For, Show } from "solid-js";
+import { Button } from "@/components/ui/button";
 import type { Reference } from "@/lib/db/queries/references";
 
 interface ReferenceListProps {
@@ -218,7 +219,7 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
             handleDragStart(e as unknown as DragEvent, itemProps.reference.id)
           }
           onDragEnd={handleDragEnd}
-          class="cursor-grab active:cursor-grabbing p-0.5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors flex-shrink-0 mt-0.5"
+          class="mt-0.5 flex-shrink-0 cursor-grab p-0.5 text-muted-foreground transition-colors hover:text-foreground active:cursor-grabbing"
           title="Drag to reorder"
           aria-label="Drag to reorder reference"
           data-testid={`reference-drag-handle-${itemProps.reference.id}`}
@@ -292,29 +293,33 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
       <Show when={showActions() && canEditReference(itemProps.reference)}>
         <div class="flex gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
           <Show when={props.onEdit}>
-            <button
+            <Button
               type="button"
               onClick={() => props.onEdit!(itemProps.reference)}
-              class="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900 rounded transition-colors"
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8 text-primary"
               title="Edit reference"
               aria-label="Edit reference"
               data-testid={`reference-edit-button-${itemProps.reference.id}`}
             >
               <SquarePen class="w-4 h-4" />
-            </button>
+            </Button>
           </Show>
 
           <Show when={props.onDelete}>
-            <button
+            <Button
               type="button"
               onClick={() => props.onDelete!(itemProps.reference.id)}
-              class="p-1.5 text-red-600 hover:bg-red-50 dark:hover:bg-red-900 rounded transition-colors"
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8 text-destructive hover:bg-destructive/10 hover:text-destructive"
               title="Delete reference"
               aria-label="Delete reference"
               data-testid={`reference-delete-button-${itemProps.reference.id}`}
             >
               <Trash2 class="w-4 h-4" />
-            </button>
+            </Button>
           </Show>
         </div>
       </Show>
@@ -325,7 +330,7 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
     <ul class="space-y-3 list-none" data-testid="references-list">
       {/* Empty state */}
       <Show when={props.references.length === 0}>
-        <div class="text-center py-8 text-gray-500 dark:text-gray-400">
+        <div class="py-8 text-center text-muted-foreground">
           <p class="text-sm italic">No references yet</p>
           <p class="text-xs mt-1">
             Add links to videos, sheet music, or articles

--- a/src/components/references/ReferenceList.tsx
+++ b/src/components/references/ReferenceList.tsx
@@ -7,7 +7,7 @@
  * @module components/references/ReferenceList
  */
 
-import { GripVertical } from "lucide-solid";
+import { GripVertical, SquarePen, Trash2 } from "lucide-solid";
 import { type Component, createSignal, For, Show } from "solid-js";
 import type { Reference } from "@/lib/db/queries/references";
 
@@ -297,22 +297,10 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
               onClick={() => props.onEdit!(itemProps.reference)}
               class="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900 rounded transition-colors"
               title="Edit reference"
+              aria-label="Edit reference"
               data-testid={`reference-edit-button-${itemProps.reference.id}`}
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <title>Edit</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                />
-              </svg>
+              <SquarePen class="w-4 h-4" />
             </button>
           </Show>
 
@@ -322,22 +310,10 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
               onClick={() => props.onDelete!(itemProps.reference.id)}
               class="p-1.5 text-red-600 hover:bg-red-50 dark:hover:bg-red-900 rounded transition-colors"
               title="Delete reference"
+              aria-label="Delete reference"
               data-testid={`reference-delete-button-${itemProps.reference.id}`}
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <title>Delete</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                />
-              </svg>
+              <Trash2 class="w-4 h-4" />
             </button>
           </Show>
         </div>

--- a/src/components/repertoire/EmptyState.tsx
+++ b/src/components/repertoire/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { type Component, For, Show } from "solid-js";
+import { Button } from "@/components/ui/button";
 import type { StarterRepertoireTemplate } from "../../lib/db/starter-repertoire-templates";
 
 interface IEmptyStateAction {
@@ -31,21 +32,17 @@ export const RepertoireEmptyState: Component<RepertoireEmptyStateProps> = (
   props
 ) => (
   <div class="flex-1 flex items-center justify-center py-10">
-    <div class="max-w-xl w-full text-center bg-gray-50 dark:bg-gray-800/50 border border-dashed border-gray-300 dark:border-gray-700 rounded-xl p-6 shadow-sm">
+    <div class="max-w-xl w-full rounded-xl border border-dashed border-border bg-muted/30 p-6 text-center shadow-sm">
       <div class="text-4xl mb-3" aria-hidden="true">
         🎵
       </div>
-      <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
-        {props.title}
-      </h3>
-      <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
-        {props.description}
-      </p>
+      <h3 class="text-xl font-semibold text-foreground">{props.title}</h3>
+      <p class="mt-2 text-sm text-muted-foreground">{props.description}</p>
 
       {/* Inline starter-repertoire picker (shown when starterTemplates prop is present) */}
       <Show when={props.starterTemplates && props.starterTemplates.length > 0}>
         <div class="mt-6 space-y-4 text-left">
-          <h4 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide text-center">
+          <h4 class="text-center text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             Starter Repertoires
           </h4>
 
@@ -57,7 +54,7 @@ export const RepertoireEmptyState: Component<RepertoireEmptyStateProps> = (
                   onClick={() => props.onStarterChosen?.(template.id)}
                   disabled={props.isCreatingStarter}
                   data-testid={`onboarding-starter-${template.id}`}
-                  class="w-full text-left border border-blue-200 dark:border-blue-700 rounded-lg p-4 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-400 dark:hover:border-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  class="w-full rounded-lg border border-border bg-background p-4 text-left transition-colors hover:border-primary/40 hover:bg-accent/30 disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-ring"
                 >
                   <div class="flex items-start gap-3">
                     <span
@@ -68,14 +65,14 @@ export const RepertoireEmptyState: Component<RepertoireEmptyStateProps> = (
                     </span>
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center gap-2 flex-wrap">
-                        <span class="font-semibold text-gray-900 dark:text-white text-sm">
+                        <span class="text-sm font-semibold text-foreground">
                           {template.name}
                         </span>
-                        <span class="text-xs bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full whitespace-nowrap">
+                        <span class="whitespace-nowrap rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
                           ~{template.estimatedTuneCount} tunes
                         </span>
                       </div>
-                      <p class="text-xs text-gray-500 dark:text-gray-400 mt-1 leading-relaxed">
+                      <p class="mt-1 text-xs leading-relaxed text-muted-foreground">
                         {template.description}
                       </p>
                     </div>
@@ -95,15 +92,16 @@ export const RepertoireEmptyState: Component<RepertoireEmptyStateProps> = (
           </div>
 
           {/* Create Custom */}
-          <button
+          <Button
             type="button"
             onClick={() => props.onCreateCustom?.()}
             disabled={props.isCreatingStarter}
-            class="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+            variant="outline"
+            class="w-full text-sm"
             data-testid="onboarding-create-repertoire"
           >
             Create Custom Repertoire
-          </button>
+          </Button>
 
           {/* Starter creation error */}
           <Show when={props.starterError}>
@@ -124,23 +122,23 @@ export const RepertoireEmptyState: Component<RepertoireEmptyStateProps> = (
         <Show when={props.primaryAction || props.secondaryAction}>
           <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
             <Show when={props.primaryAction}>
-              <button
+              <Button
                 type="button"
-                class="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                variant="outline"
                 onClick={() => props.primaryAction?.onClick()}
               >
                 {props.primaryAction?.label}
-              </button>
+              </Button>
             </Show>
 
             <Show when={props.secondaryAction}>
-              <button
+              <Button
                 type="button"
-                class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                variant="outline"
                 onClick={() => props.secondaryAction?.onClick()}
               >
                 {props.secondaryAction?.label}
-              </button>
+              </Button>
             </Show>
           </div>
         </Show>

--- a/src/components/repertoire/RepertoireToolbar.tsx
+++ b/src/components/repertoire/RepertoireToolbar.tsx
@@ -9,7 +9,15 @@
 
 import { DropdownMenu } from "@kobalte/core/dropdown-menu";
 import type { Table } from "@tanstack/solid-table";
-import { ChevronRight, Columns, EllipsisVertical, Plus } from "lucide-solid";
+import {
+  ChevronDown,
+  ChevronRight,
+  Columns,
+  EllipsisVertical,
+  Minus,
+  Plus,
+  Search,
+} from "lucide-solid";
 import type { Component } from "solid-js";
 import {
   createEffect,
@@ -396,20 +404,7 @@ export const RepertoireToolbar: Component<RepertoireToolbarProps> = (props) => {
     return (
       <div class="flex min-w-0 flex-1 items-center gap-2">
         <div class="relative min-w-0 flex-1">
-          <svg
-            class={TOOLBAR_SEARCH_ICON}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
-          </svg>
+          <Search class={TOOLBAR_SEARCH_ICON} aria-hidden="true" />
           <input
             type="text"
             placeholder="Search tunes..."
@@ -563,38 +558,12 @@ export const RepertoireToolbar: Component<RepertoireToolbarProps> = (props) => {
                 data-testid="add-to-review-button"
                 disabled={!hasSelectedRows()}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-                  />
-                </svg>
+                <Plus class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Add To Review</span>
               </button>
 
               <div class={TOOLBAR_SEARCH_CONTAINER}>
-                <svg
-                  class={TOOLBAR_SEARCH_ICON}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                  />
-                </svg>
+                <Search class={TOOLBAR_SEARCH_ICON} aria-hidden="true" />
                 <input
                   type="text"
                   placeholder="Search tunes..."
@@ -644,20 +613,7 @@ export const RepertoireToolbar: Component<RepertoireToolbarProps> = (props) => {
                 disabled={!hasSelectedRows()}
                 class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_SUCCESS}`}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 7h16M4 12h16M4 17h10"
-                  />
-                </svg>
+                <Plus class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Add to Set</span>
               </button>
 
@@ -668,20 +624,7 @@ export const RepertoireToolbar: Component<RepertoireToolbarProps> = (props) => {
                 data-testid="repertoire-add-tune-button"
                 class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_SUCCESS}`}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M12 4v16m8-8H4"
-                  />
-                </svg>
+                <Plus class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Add Tune</span>
               </button>
 
@@ -695,20 +638,7 @@ export const RepertoireToolbar: Component<RepertoireToolbarProps> = (props) => {
                 }
                 class={`${TOOLBAR_BUTTON_BASE} ${TOOLBAR_BUTTON_WARNING}`}
               >
-                <svg
-                  class={TOOLBAR_ICON_SIZE}
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
+                <Minus class={TOOLBAR_ICON_SIZE} aria-hidden="true" />
                 <span>Remove From Repertoire</span>
               </button>
             </div>
@@ -738,20 +668,7 @@ export const RepertoireToolbar: Component<RepertoireToolbarProps> = (props) => {
                 >
                   <Columns size={14} />
                   <span>Display Options</span>
-                  <svg
-                    class="w-3.5 h-3.5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
+                  <ChevronDown class="w-3.5 h-3.5" aria-hidden="true" />
                 </button>
               </div>
             </div>

--- a/src/components/repertoires/RepertoireEditorDialog.tsx
+++ b/src/components/repertoires/RepertoireEditorDialog.tsx
@@ -14,7 +14,7 @@
  * @module components/repertoires/RepertoireEditorDialog
  */
 
-import { CircleX, Save } from "lucide-solid";
+import { Save } from "lucide-solid";
 import type { Component } from "solid-js";
 import {
   createResource,
@@ -23,6 +23,7 @@ import {
   onMount,
   Show,
 } from "solid-js";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "../../lib/auth/AuthContext";
 import {
   createRepertoire,
@@ -167,48 +168,54 @@ export const RepertoireEditorDialog: Component<RepertoireEditorDialogProps> = (
         data-testid="repertoire-editor-dialog"
       >
         {/* Header */}
-        <div class="flex items-center justify-between p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700">
-          <h2
-            id="repertoire-editor-title"
-            class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white"
-          >
-            {props.repertoireId ? "Edit Repertoire" : "Create New Repertoire"}
-          </h2>
-          <div class="flex items-center gap-4">
-            <button
-              type="button"
-              onClick={props.onClose}
-              disabled={isSaving()}
-              class="text-gray-700 dark:text-gray-300 hover:underline text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Cancel and close dialog"
-              data-testid="cancel-repertoire-button"
-            >
-              <div class="flex items-center gap-2">
-                <span>Cancel</span>
-                <CircleX size={20} />
-              </div>
-            </button>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={isSaving()}
-              class="text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-              aria-label="Save repertoire"
-              data-testid="save-repertoire-button"
-            >
-              <Show
-                when={isSaving()}
-                fallback={
-                  <>
-                    Save <Save size={24} />
-                  </>
-                }
+        <div class="border-b border-gray-200 p-4 dark:border-gray-700 sm:p-6">
+          <header class="flex justify-between items-center w-full mb-4">
+            <div class="flex flex-1 justify-start">
+              <Button
+                type="button"
+                onClick={props.onClose}
+                disabled={isSaving()}
+                variant="outline"
+                size="sm"
+                aria-label="Cancel and close dialog"
+                data-testid="cancel-repertoire-button"
               >
-                <div class="animate-spin h-4 w-4 border-2 border-blue-600 dark:border-blue-400 border-t-transparent rounded-full" />
-                Saving...
-              </Show>
-            </button>
-          </div>
+                Cancel
+              </Button>
+            </div>
+            <div class="flex min-w-0 flex-1 justify-center px-3">
+              <h2
+                id="repertoire-editor-title"
+                class="text-center text-xl font-bold text-gray-900 dark:text-white sm:text-2xl"
+              >
+                {props.repertoireId ? "Edit Repertoire" : "Create Repertoire"}
+              </h2>
+            </div>
+            <div class="flex flex-1 justify-end">
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={isSaving()}
+                variant="default"
+                size="sm"
+                aria-label="Save repertoire"
+                data-testid="save-repertoire-button"
+              >
+                <Show
+                  when={isSaving()}
+                  fallback={
+                    <>
+                      <Save size={16} />
+                      Save
+                    </>
+                  }
+                >
+                  <div class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  Saving...
+                </Show>
+              </Button>
+            </div>
+          </header>
         </div>
 
         {/* Content - Scrollable */}

--- a/src/components/repertoires/RepertoireList.tsx
+++ b/src/components/repertoires/RepertoireList.tsx
@@ -20,7 +20,7 @@ import {
   getSortedRowModel,
   type SortingState,
 } from "@tanstack/solid-table";
-import { Pencil, Trash2 } from "lucide-solid";
+import { SquarePen, Trash2 } from "lucide-solid";
 import {
   type Component,
   createMemo,
@@ -249,7 +249,7 @@ export const RepertoireList: Component<RepertoireListProps> = (props) => {
               title="Edit repertoire"
               aria-label="Edit repertoire"
             >
-              <Pencil size={16} />
+              <SquarePen size={16} />
             </button>
             <button
               type="button"

--- a/src/components/repertoires/RepertoireManagerDialog.tsx
+++ b/src/components/repertoires/RepertoireManagerDialog.tsx
@@ -16,7 +16,7 @@
  * @module components/repertoires/RepertoireManagerDialog
  */
 
-import { X } from "lucide-solid";
+import { Plus, X } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createSignal, onCleanup, onMount, Show } from "solid-js";
 import { useAuth } from "../../lib/auth/AuthContext";
@@ -134,20 +134,7 @@ export const RepertoireManagerDialog: Component<
               class="px-3 py-2 sm:px-4 text-xs sm:text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center gap-1 sm:gap-2"
               data-testid="create-repertoire-button"
             >
-              <svg
-                class="w-4 h-4 sm:w-5 sm:h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 4v16m8-8H4"
-                />
-              </svg>
+              <Plus class="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
               <span class="hidden sm:inline">New Repertoire</span>
               <span class="sm:hidden">New</span>
             </button>

--- a/src/components/repertoires/RepertoireSelector.tsx
+++ b/src/components/repertoires/RepertoireSelector.tsx
@@ -14,6 +14,7 @@
  * @module components/repertoires/RepertoireSelector
  */
 
+import { Check, ChevronDown } from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -167,20 +168,10 @@ export const RepertoireSelector: Component<RepertoireSelectorProps> = (
         </Show>
 
         {/* Dropdown Arrow */}
-        <svg
+        <ChevronDown
           class={`w-5 h-5 text-gray-400 transition-transform ${isOpen() ? "rotate-180" : ""}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
           aria-hidden="true"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 9l-7 7-7-7"
-          />
-        </svg>
+        />
       </button>
 
       {/* Error Message */}
@@ -223,18 +214,10 @@ export const RepertoireSelector: Component<RepertoireSelectorProps> = (
                   <Show
                     when={repertoire.repertoireId === selectedRepertoireId()}
                   >
-                    <svg
+                    <Check
                       class="w-5 h-5 text-blue-600 dark:text-blue-400"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
                       aria-hidden="true"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                        clip-rule="evenodd"
-                      />
-                    </svg>
+                    />
                   </Show>
                 </div>
               </button>

--- a/src/components/tune-sets/GroupAsSetPopover.tsx
+++ b/src/components/tune-sets/GroupAsSetPopover.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
+import { Button } from "@/components/ui/button";
 import type { TuneSetWithSummary } from "@/lib/db/queries/tune-sets";
 
 interface GroupAsSetPopoverProps {
@@ -68,15 +69,16 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
           </p>
         </div>
 
-        <button
+        <Button
           type="button"
-          class="flex h-10 w-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+          variant="ghost"
+          size="icon"
           onClick={props.onClose}
           aria-label="Close group as set popover"
           data-testid="close-group-as-set-popover-button"
         >
           <X class="h-5 w-5" aria-hidden="true" />
-        </button>
+        </Button>
       </div>
 
       <div
@@ -87,14 +89,14 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
           type="button"
           class={`rounded-xl border px-4 py-3 text-left transition-colors ${
             mode() === "create"
-              ? "border-blue-500 bg-blue-50 text-blue-900 dark:border-blue-400 dark:bg-blue-950/40 dark:text-blue-100"
-              : "border-gray-200 bg-white text-gray-900 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800"
+              ? "border-primary bg-primary/5 text-foreground"
+              : "border-border bg-background text-foreground hover:bg-accent/30"
           }`}
           onClick={() => setMode("create")}
           data-testid="group-as-set-create-mode-button"
         >
           <div class="text-sm font-semibold">Create New Set</div>
-          <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          <div class="mt-1 text-xs text-muted-foreground">
             Name and save this selection as a new reusable set.
           </div>
         </button>
@@ -103,14 +105,14 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
           type="button"
           class={`rounded-xl border px-4 py-3 text-left transition-colors ${
             mode() === "existing"
-              ? "border-blue-500 bg-blue-50 text-blue-900 dark:border-blue-400 dark:bg-blue-950/40 dark:text-blue-100"
-              : "border-gray-200 bg-white text-gray-900 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800"
+              ? "border-primary bg-primary/5 text-foreground"
+              : "border-border bg-background text-foreground hover:bg-accent/30"
           }`}
           onClick={() => setMode("existing")}
           data-testid="group-as-set-existing-mode-button"
         >
           <div class="text-sm font-semibold">Add to Existing Set</div>
-          <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          <div class="mt-1 text-xs text-muted-foreground">
             Pick one of your current sets and add this selection there.
           </div>
         </button>
@@ -206,12 +208,12 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
                       <Show
                         when={props.addingToSetId === tuneSet.id}
                         fallback={
-                          <span class="text-xs font-medium text-blue-600 dark:text-blue-400">
+                          <span class="text-xs font-medium text-primary">
                             Add
                           </span>
                         }
                       >
-                        <div class="h-4 w-4 animate-spin rounded-full border-2 border-blue-600 border-t-transparent dark:border-blue-400" />
+                        <div class="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
                       </Show>
                     </button>
                   )}
@@ -246,18 +248,18 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
         <p class="mt-3 text-sm text-red-600 dark:text-red-400">{props.error}</p>
       </Show>
 
-      <div class="mt-4 flex items-center justify-end gap-3">
-        <button
+      <div class="mt-4 flex w-full items-center justify-between gap-3">
+        <Button
           type="button"
-          class="rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+          variant="outline"
           onClick={props.onClose}
           disabled={props.isSaving || Boolean(props.addingToSetId)}
         >
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
-          class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          variant="default"
           onClick={handleSave}
           disabled={
             mode() !== "create" ||
@@ -269,7 +271,7 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
           <Show when={props.isSaving} fallback={<span>Create New Set</span>}>
             <span>Saving...</span>
           </Show>
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/tune-sets/GroupAsSetPopover.tsx
+++ b/src/components/tune-sets/GroupAsSetPopover.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 import type { TuneSetWithSummary } from "@/lib/db/queries/tune-sets";
@@ -74,20 +75,7 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
           aria-label="Close group as set popover"
           data-testid="close-group-as-set-popover-button"
         >
-          <svg
-            class="h-5 w-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
+          <X class="h-5 w-5" aria-hidden="true" />
         </button>
       </div>
 

--- a/src/components/tune-sets/GroupAsSetPopover.tsx
+++ b/src/components/tune-sets/GroupAsSetPopover.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-solid";
+import { Plus } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createEffect, createSignal, For, onCleanup, Show } from "solid-js";
 import { Button } from "@/components/ui/button";
@@ -55,31 +55,56 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
       aria-labelledby="group-as-set-title"
       data-testid="group-as-set-popover"
     >
-      <div class="flex items-start justify-between gap-3">
-        <div>
+      <header class="flex justify-between items-center w-full mb-4">
+        <div class="flex flex-1 justify-start">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={props.onClose}
+            disabled={props.isSaving || Boolean(props.addingToSetId)}
+          >
+            Cancel
+          </Button>
+        </div>
+        <div class="flex min-w-0 flex-1 justify-center px-3">
           <h3
             id="group-as-set-title"
-            class="text-base font-semibold text-gray-900 dark:text-white"
+            class="text-center text-base font-semibold text-gray-900 dark:text-white"
           >
             Save Selection as Set
           </h3>
-          <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-            Choose what to do with these {props.tuneTitles.length} selected
-            {props.tuneTitles.length === 1 ? " tune" : " tunes"}.
-          </p>
         </div>
+        <div class="flex flex-1 justify-end">
+          <Button
+            type="button"
+            variant="default"
+            onClick={handleSave}
+            disabled={
+              mode() !== "create" ||
+              props.isSaving ||
+              Boolean(props.addingToSetId)
+            }
+            data-testid="save-group-as-set-button"
+          >
+            <Show
+              when={props.isSaving}
+              fallback={
+                <>
+                  <Plus class="h-4 w-4" />
+                  Create
+                </>
+              }
+            >
+              <span>Saving...</span>
+            </Show>
+          </Button>
+        </div>
+      </header>
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          onClick={props.onClose}
-          aria-label="Close group as set popover"
-          data-testid="close-group-as-set-popover-button"
-        >
-          <X class="h-5 w-5" aria-hidden="true" />
-        </Button>
-      </div>
+      <p class="text-sm text-gray-600 dark:text-gray-400">
+        Choose what to do with these {props.tuneTitles.length} selected
+        {props.tuneTitles.length === 1 ? " tune" : " tunes"}.
+      </p>
 
       <div
         class="mt-4 grid gap-3 sm:grid-cols-2"
@@ -247,32 +272,6 @@ export const GroupAsSetPopover: Component<GroupAsSetPopoverProps> = (props) => {
       <Show when={props.error}>
         <p class="mt-3 text-sm text-red-600 dark:text-red-400">{props.error}</p>
       </Show>
-
-      <div class="mt-4 flex w-full items-center justify-between gap-3">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={props.onClose}
-          disabled={props.isSaving || Boolean(props.addingToSetId)}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          variant="default"
-          onClick={handleSave}
-          disabled={
-            mode() !== "create" ||
-            props.isSaving ||
-            Boolean(props.addingToSetId)
-          }
-          data-testid="save-group-as-set-button"
-        >
-          <Show when={props.isSaving} fallback={<span>Create New Set</span>}>
-            <span>Saving...</span>
-          </Show>
-        </Button>
-      </div>
     </div>
   );
 

--- a/src/components/tune-sets/TuneSetEditorDialog.tsx
+++ b/src/components/tune-sets/TuneSetEditorDialog.tsx
@@ -1,4 +1,4 @@
-import { CircleX, Save } from "lucide-solid";
+import { Save } from "lucide-solid";
 import type { Component } from "solid-js";
 import {
   createEffect,
@@ -10,6 +10,7 @@ import {
 } from "solid-js";
 import { toast } from "solid-sonner";
 import { TunePickerDialog } from "@/components/tune-sets/TunePickerDialog";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useCurrentTuneSet } from "@/lib/context/CurrentTuneSetContext";
 import {
@@ -324,48 +325,54 @@ export const TuneSetEditorDialog: Component<TuneSetEditorDialogProps> = (
         aria-labelledby="tune-set-editor-title"
         data-testid="tune-set-editor-dialog"
       >
-        <div class="flex items-center justify-between p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700">
-          <h2
-            id="tune-set-editor-title"
-            class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white"
-          >
-            {dialogTitle()}
-          </h2>
-          <div class="flex items-center gap-4">
-            <button
-              type="button"
-              onClick={props.onClose}
-              disabled={isSaving()}
-              class="text-gray-700 dark:text-gray-300 hover:underline text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-              data-testid="cancel-tune-set-button"
-            >
-              <div class="flex items-center gap-2">
-                <span>{canManage() ? "Cancel" : "Close"}</span>
-                <CircleX size={20} />
-              </div>
-            </button>
-            <Show when={canManage()}>
-              <button
+        <div class="border-b border-gray-200 p-4 dark:border-gray-700 sm:p-6">
+          <header class="flex justify-between items-center w-full mb-4">
+            <div class="flex flex-1 justify-start">
+              <Button
                 type="button"
-                onClick={handleSave}
+                onClick={props.onClose}
                 disabled={isSaving()}
-                class="text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                data-testid="save-tune-set-button"
+                variant={canManage() ? "outline" : "ghost"}
+                size="sm"
+                data-testid="cancel-tune-set-button"
               >
-                <Show
-                  when={isSaving()}
-                  fallback={
-                    <>
-                      Save <Save size={24} />
-                    </>
-                  }
+                {canManage() ? "Cancel" : "Back"}
+              </Button>
+            </div>
+            <div class="flex min-w-0 flex-1 justify-center px-3">
+              <h2
+                id="tune-set-editor-title"
+                class="text-center text-xl font-bold text-gray-900 dark:text-white sm:text-2xl"
+              >
+                {dialogTitle()}
+              </h2>
+            </div>
+            <div class="flex flex-1 justify-end">
+              <Show when={canManage()}>
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={isSaving()}
+                  variant="default"
+                  size="sm"
+                  data-testid="save-tune-set-button"
                 >
-                  <div class="animate-spin h-4 w-4 border-2 border-blue-600 dark:border-blue-400 border-t-transparent rounded-full" />
-                  Saving...
-                </Show>
-              </button>
-            </Show>
-          </div>
+                  <Show
+                    when={isSaving()}
+                    fallback={
+                      <>
+                        <Save size={16} />
+                        Save
+                      </>
+                    }
+                  >
+                    <div class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                    Saving...
+                  </Show>
+                </Button>
+              </Show>
+            </div>
+          </header>
         </div>
 
         <div class="flex-1 overflow-y-auto p-4 sm:p-6 space-y-4">

--- a/src/components/tune-sets/TuneSetFilterDialog.tsx
+++ b/src/components/tune-sets/TuneSetFilterDialog.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createResource, createSignal, For, Show } from "solid-js";
 import { useAuth } from "@/lib/auth/AuthContext";
@@ -78,20 +79,7 @@ export const TuneSetFilterDialog: Component<TuneSetFilterDialogProps> = (
               aria-label="Close tune-set filter dialog"
               data-testid="close-tune-set-filter-dialog"
             >
-              <svg
-                class="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <X class="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
 

--- a/src/components/tune-sets/TuneSetList.tsx
+++ b/src/components/tune-sets/TuneSetList.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2 } from "lucide-solid";
+import { SquarePen, Trash2 } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createMemo, createResource, createSignal, For, Show } from "solid-js";
 import { useAuth } from "@/lib/auth/AuthContext";
@@ -115,7 +115,7 @@ export const TuneSetList: Component<TuneSetListProps> = (props) => {
                         aria-label="Edit tune set"
                         data-testid="edit-tune-set-button"
                       >
-                        <Pencil size={16} />
+                        <SquarePen size={16} />
                       </button>
                       <button
                         type="button"

--- a/src/components/tune-sets/TuneSetManagerDialog.tsx
+++ b/src/components/tune-sets/TuneSetManagerDialog.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-solid";
+import { Plus, X } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createSignal, onCleanup, onMount, Show } from "solid-js";
 import type { TuneSetWithSummary } from "@/lib/db/queries/tune-sets";
@@ -79,20 +79,7 @@ export const TuneSetManagerDialog: Component<TuneSetManagerDialogProps> = (
               class="px-3 py-2 sm:px-4 text-xs sm:text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center gap-1 sm:gap-2"
               data-testid="create-tune-set-button"
             >
-              <svg
-                class="w-4 h-4 sm:w-5 sm:h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 4v16m8-8H4"
-                />
-              </svg>
+              <Plus class="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
               <span class="hidden sm:inline">New Tune Set</span>
               <span class="sm:hidden">New</span>
             </button>

--- a/src/components/tunes/BulkActionsBar.tsx
+++ b/src/components/tunes/BulkActionsBar.tsx
@@ -11,6 +11,7 @@
  * @module components/tunes/BulkActionsBar
  */
 
+import { Download, Plus, Tag, Trash2, X } from "lucide-solid";
 import { type Component, Show } from "solid-js";
 
 interface BulkActionsBarProps {
@@ -68,21 +69,7 @@ export const BulkActionsBar: Component<BulkActionsBarProps> = (props) => {
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-600 transition-colors"
               title="Add selected tunes to a repertoire"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-label="Repertoire icon"
-              >
-                <title>Add to Repertoire</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-                />
-              </svg>
+              <Plus class="w-4 h-4" />
               <span>Add to Repertoire</span>
             </button>
 
@@ -92,21 +79,7 @@ export const BulkActionsBar: Component<BulkActionsBarProps> = (props) => {
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-600 transition-colors"
               title="Add tags to selected tunes"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-label="Tag icon"
-              >
-                <title>Add Tags</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
-                />
-              </svg>
+              <Tag class="w-4 h-4" />
               <span>Add Tags</span>
             </button>
 
@@ -116,21 +89,7 @@ export const BulkActionsBar: Component<BulkActionsBarProps> = (props) => {
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-red-600 border border-transparent rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:bg-red-700 dark:hover:bg-red-800 transition-colors"
               title="Delete selected tunes"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-label="Delete icon"
-              >
-                <title>Delete</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                />
-              </svg>
+              <Trash2 class="w-4 h-4" />
               <span>Delete</span>
             </button>
 
@@ -140,21 +99,7 @@ export const BulkActionsBar: Component<BulkActionsBarProps> = (props) => {
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-600 transition-colors"
               title="Export selected tunes as JSON"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-label="Export icon"
-              >
-                <title>Export</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                />
-              </svg>
+              <Download class="w-4 h-4" />
               <span>Export</span>
             </button>
 
@@ -165,21 +110,7 @@ export const BulkActionsBar: Component<BulkActionsBarProps> = (props) => {
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 transition-colors"
               title="Clear selection"
             >
-              <svg
-                class="w-4 h-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-label="Clear icon"
-              >
-                <title>Clear Selection</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <X class="w-4 h-4" />
               <span>Clear</span>
             </button>
           </div>

--- a/src/components/tunes/FilterBar.tsx
+++ b/src/components/tunes/FilterBar.tsx
@@ -12,6 +12,7 @@
  * @module components/tunes/FilterBar
  */
 
+import { Search } from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -132,20 +133,10 @@ export const FilterBar: Component<FilterBarProps> = (props) => {
             placeholder="Search/filter tunes by title, artist, composer, incipit, or structure"
             class="w-full px-4 py-2 pl-10 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
-          <svg
+          <Search
             class="absolute left-3 top-2.5 w-5 h-5 text-gray-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <title>Search icon</title>
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
-          </svg>
+            aria-hidden="true"
+          />
         </div>
       </div>
 

--- a/src/components/tunes/RepertoireSelectorModal.tsx
+++ b/src/components/tunes/RepertoireSelectorModal.tsx
@@ -1,3 +1,4 @@
+import { Check } from "lucide-solid";
 import {
   type Component,
   createResource,
@@ -158,20 +159,10 @@ export const RepertoireSelectorModal: Component<
                           selectedRepertoireId() === repertoireItem.repertoireId
                         }
                       >
-                        <svg
+                        <Check
                           class="h-5 w-5 text-blue-500 dark:text-blue-400"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <title>Selected</title>
-                          <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M5 13l4 4L19 7"
-                          />
-                        </svg>
+                          aria-hidden="true"
+                        />
                       </Show>
                     </div>
                   </button>

--- a/src/components/tunes/RepertoireSelectorModal.tsx
+++ b/src/components/tunes/RepertoireSelectorModal.tsx
@@ -6,6 +6,7 @@ import {
   For,
   Show,
 } from "solid-js";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { getUserRepertoires } from "@/lib/db/queries/repertoires";
 import type { RepertoireWithSummary } from "@/lib/db/types";
@@ -135,10 +136,10 @@ export const RepertoireSelectorModal: Component<
                 {(repertoireItem: RepertoireWithSummary) => (
                   <button
                     type="button"
-                    class={`w-full rounded-lg border-2 p-3 text-left transition-colors ${
+                    class={`w-full rounded-lg border-2 bg-card p-3 text-left transition-colors ${
                       selectedRepertoireId() === repertoireItem.repertoireId
-                        ? "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-900/20"
-                        : "border-gray-200 bg-white hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600"
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-muted-foreground/40 hover:bg-accent/30"
                     }`}
                     onClick={() =>
                       setSelectedRepertoireId(repertoireItem.repertoireId)
@@ -146,10 +147,10 @@ export const RepertoireSelectorModal: Component<
                   >
                     <div class="flex items-center justify-between">
                       <div class="flex-1">
-                        <div class="font-medium text-gray-900 dark:text-white">
+                        <div class="font-medium text-foreground">
                           {repertoireItem.name}
                         </div>
-                        <div class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                        <div class="mt-1 text-sm text-muted-foreground">
                           {repertoireItem.tuneCount}{" "}
                           {repertoireItem.tuneCount === 1 ? "tune" : "tunes"}
                         </div>
@@ -160,7 +161,7 @@ export const RepertoireSelectorModal: Component<
                         }
                       >
                         <Check
-                          class="h-5 w-5 text-blue-500 dark:text-blue-400"
+                          class="h-5 w-5 text-primary"
                           aria-hidden="true"
                         />
                       </Show>
@@ -172,22 +173,18 @@ export const RepertoireSelectorModal: Component<
           </Show>
         </Show>
 
-        <div class="flex justify-end gap-3">
-          <button
-            type="button"
-            class="rounded-lg bg-gray-100 px-4 py-2 text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-            onClick={handleCancel}
-          >
+        <div class="flex w-full justify-between gap-3">
+          <Button type="button" onClick={handleCancel} variant="outline">
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
-            class="rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
             onClick={handleSelect}
             disabled={selectedRepertoireId() === null}
+            variant="default"
           >
             Add to Repertoire
-          </button>
+          </Button>
         </div>
       </div>
     </Show>

--- a/src/components/tunes/TagInput.tsx
+++ b/src/components/tunes/TagInput.tsx
@@ -5,6 +5,7 @@
  * Displays selected tags as removable chips/badges.
  */
 
+import { X } from "lucide-solid";
 import type { Component } from "solid-js";
 import { createResource, createSignal, For, Show } from "solid-js";
 import { useAuth } from "@/lib/auth/AuthContext";
@@ -114,19 +115,7 @@ export const TagInput: Component<TagInputProps> = (props) => {
                 class="hover:text-blue-600 dark:hover:text-blue-300 focus:outline-none disabled:opacity-50"
                 aria-label={`Remove tag ${tag}`}
               >
-                <svg
-                  class="w-3 h-3"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <title>Remove</title>
-                  <path
-                    fill-rule="evenodd"
-                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
+                <X class="w-3 h-3" aria-hidden="true" />
               </button>
             </span>
           )}

--- a/src/components/tunes/TuneEditor.tsx
+++ b/src/components/tunes/TuneEditor.tsx
@@ -494,71 +494,61 @@ export const TuneEditor: Component<TuneEditorProps> = (props) => {
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg">
           {/* Header with buttons inside constrained area (only when not hidden) */}
           <Show when={!props.hideButtons}>
-            <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-              {/* Left: Title */}
-              <div class="flex items-center gap-6">
-                <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-                  {props.readOnly
-                    ? title()
-                    : props.tune
-                      ? "Edit Tune"
-                      : "New Tune"}
-                </h2>
-              </div>
-
-              {/* Right: Action buttons */}
-              <Show
-                when={props.readOnly}
-                fallback={
-                  <div class="flex items-center gap-2">
-                    <Button
-                      type="button"
-                      onClick={handleCancel}
-                      disabled={isSaving()}
-                      variant="outline"
-                      size="sm"
-                      data-testid="tune-editor-cancel-button"
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      type="button"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        void handleSave();
-                      }}
-                      disabled={isSaving() || !isDirty()}
-                      data-testid="tune-editor-save-button"
-                      size="sm"
-                    >
-                      <Save size={16} />
-                      Save
-                    </Button>
-                  </div>
-                }
-              >
-                <div class="flex items-center gap-2">
+            <div class="border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+              <header class="flex justify-between items-center w-full mb-4">
+                <div class="flex flex-1 justify-start">
                   <Button
                     type="button"
-                    onClick={props.onCancel}
-                    data-testid="tune-editor-cancel-button"
+                    onClick={handleCancel}
+                    disabled={isSaving()}
                     variant="outline"
                     size="sm"
+                    data-testid="tune-editor-cancel-button"
                   >
                     Cancel
                   </Button>
-                  <Button
-                    type="button"
-                    onClick={props.onEdit}
-                    data-testid="tune-editor-edit-button"
-                    variant="outline"
-                    size="sm"
-                  >
-                    <SquarePen size={16} />
-                    Edit
-                  </Button>
                 </div>
-              </Show>
+                <div class="flex min-w-0 flex-1 justify-center px-3">
+                  <h2 class="text-center text-lg font-semibold text-gray-900 dark:text-white">
+                    {props.readOnly
+                      ? title()
+                      : props.tune
+                        ? "Edit Tune"
+                        : "Create Tune"}
+                  </h2>
+                </div>
+                <div class="flex flex-1 justify-end">
+                  <Show
+                    when={props.readOnly}
+                    fallback={
+                      <Button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          void handleSave();
+                        }}
+                        disabled={isSaving() || !isDirty()}
+                        data-testid="tune-editor-save-button"
+                        size="sm"
+                      >
+                        <Save size={16} />
+                        Save
+                      </Button>
+                    }
+                  >
+                    <Button
+                      type="button"
+                      onClick={props.onEdit}
+                      data-testid="tune-editor-edit-button"
+                      variant="outline"
+                      size="sm"
+                    >
+                      <SquarePen size={16} />
+                      Edit
+                    </Button>
+                  </Show>
+                </div>
+              </header>
             </div>
           </Show>
 

--- a/src/components/tunes/TuneEditor.tsx
+++ b/src/components/tunes/TuneEditor.tsx
@@ -13,7 +13,7 @@
 import { A } from "@solidjs/router";
 import abcjs from "abcjs";
 import { eq } from "drizzle-orm";
-import { CircleX, History, Layers, Pencil, Save, Undo2 } from "lucide-solid";
+import { History, Layers, Save, SquarePen, Undo2 } from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -36,6 +36,7 @@ import {
   removeTagFromTune,
 } from "@/lib/db/queries/tags";
 import type { Tune } from "../../lib/db/types";
+import { Button } from "../ui/button";
 import {
   Select,
   SelectContent,
@@ -509,58 +510,53 @@ export const TuneEditor: Component<TuneEditorProps> = (props) => {
               <Show
                 when={props.readOnly}
                 fallback={
-                  <div class="flex items-center gap-3">
-                    <button
+                  <div class="flex items-center gap-2">
+                    <Button
                       type="button"
                       onClick={handleCancel}
                       disabled={isSaving()}
-                      class="text-gray-700 dark:text-gray-300 hover:underline text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-                      aria-label="Cancel"
+                      variant="outline"
+                      size="sm"
                       data-testid="tune-editor-cancel-button"
                     >
-                      <div class="flex items-center gap-2">
-                        <span>Cancel</span>
-                        <CircleX size={20} />
-                      </div>
-                    </button>
-                    <button
-                      type="submit"
+                      Cancel
+                    </Button>
+                    <Button
+                      type="button"
                       onClick={(e) => {
                         e.preventDefault();
                         void handleSave();
                       }}
                       disabled={isSaving() || !isDirty()}
                       data-testid="tune-editor-save-button"
-                      class="text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                      aria-label="Save"
+                      size="sm"
                     >
-                      Save <Save size={24} />
-                    </button>
+                      <Save size={16} />
+                      Save
+                    </Button>
                   </div>
                 }
               >
-                <div class="flex items-center gap-3">
-                  <button
+                <div class="flex items-center gap-2">
+                  <Button
                     type="button"
                     onClick={props.onCancel}
                     data-testid="tune-editor-cancel-button"
-                    class="text-gray-700 dark:text-gray-300 hover:underline text-sm font-medium"
-                    aria-label="Cancel"
+                    variant="outline"
+                    size="sm"
                   >
-                    <div class="flex items-center gap-2">
-                      <span>Cancel</span>
-                      <CircleX size={20} />
-                    </div>
-                  </button>
-                  <button
+                    Cancel
+                  </Button>
+                  <Button
                     type="button"
                     onClick={props.onEdit}
                     data-testid="tune-editor-edit-button"
-                    class="text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium flex items-center gap-2"
-                    aria-label="Edit"
+                    variant="outline"
+                    size="sm"
                   >
-                    Edit <Pencil size={24} />
-                  </button>
+                    <SquarePen size={16} />
+                    Edit
+                  </Button>
                 </div>
               </Show>
             </div>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -15,6 +15,7 @@ import type {
 } from "@kobalte/core/dialog";
 import { Dialog as DialogPrimitive } from "@kobalte/core/dialog";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import { X } from "lucide-solid";
 import type { ParentProps, ValidComponent, VoidProps } from "solid-js";
 import { splitProps } from "solid-js";
 import { cn } from "@/lib/utils";
@@ -146,20 +147,7 @@ export const AlertDialogCloseButton = <T extends ValidComponent = "button">(
       )}
       {...rest}
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class="h-4 w-4"
-      >
-        <title>Close</title>
-        <path d="M18 6 6 18" />
-        <path d="m6 6 12 12" />
-      </svg>
+      <X class="h-4 w-4" aria-hidden="true" />
       <span class="sr-only">Close</span>
     </DialogPrimitive.CloseButton>
   );

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -13,6 +13,7 @@ import type {
 } from "@kobalte/core/checkbox";
 import { Checkbox as CheckboxPrimitive } from "@kobalte/core/checkbox";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import { Check } from "lucide-solid";
 import type { ParentProps, ValidComponent } from "solid-js";
 import { splitProps } from "solid-js";
 import { cn } from "@/lib/utils";
@@ -78,19 +79,7 @@ export const CheckboxIndicator = <T extends ValidComponent = "div">(
       class={cn("flex items-center justify-center text-current", local.class)}
       {...rest}
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        class="h-4 w-4"
-      >
-        <title>Checkmark</title>
-        <polyline points="20 6 9 17 4 12" />
-      </svg>
+      <Check class="h-4 w-4" aria-hidden="true" />
     </CheckboxPrimitive.Indicator>
   );
 };

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@kobalte/core/combobox";
 import { Combobox as ComboboxPrimitive } from "@kobalte/core/combobox";
 import type { PolymorphicProps } from "@kobalte/core/polymorphic";
+import { Check, ChevronsUpDown } from "lucide-solid";
 import type { ParentProps, ValidComponent, VoidProps } from "solid-js";
 import { splitProps } from "solid-js";
 import { cn } from "@/lib/utils";
@@ -66,21 +67,7 @@ export const ComboboxTrigger = <T extends ValidComponent = "button">(
           aria-hidden="true"
           class="flex h-3.5 w-3.5 items-center justify-center"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-            class="h-4 w-4 opacity-50"
-          >
-            <path
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="m8 9l4-4l4 4m0 6l-4 4l-4-4"
-            />
-          </svg>
+          <ChevronsUpDown class="h-4 w-4 opacity-50" aria-hidden="true" />
         </ComboboxPrimitive.Icon>
       </ComboboxPrimitive.Trigger>
     </ComboboxPrimitive.Control>
@@ -138,21 +125,7 @@ export const ComboboxItem = <T extends ValidComponent = "li">(
         aria-hidden="true"
         class="absolute right-2 flex h-3.5 w-3.5 items-center justify-center"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          class="h-4 w-4"
-        >
-          <path
-            fill="none"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="m5 12l5 5L20 7"
-          />
-        </svg>
+        <Check class="h-4 w-4" aria-hidden="true" />
       </ComboboxPrimitive.ItemIndicator>
       <ComboboxPrimitive.ItemLabel>
         {local.children}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -14,6 +14,7 @@ import type {
   SelectTriggerProps,
 } from "@kobalte/core/select";
 import { Select as SelectPrimitive } from "@kobalte/core/select";
+import { Check, ChevronDown } from "lucide-solid";
 import type { ParentProps, ValidComponent } from "solid-js";
 import { splitProps } from "solid-js";
 import { cn } from "@/lib/utils";
@@ -59,19 +60,7 @@ export const SelectTrigger = <T extends ValidComponent = "button">(
     >
       {local.children}
       <SelectPrimitive.Icon class="flex h-4 w-4 items-center justify-center">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="h-4 w-4 opacity-50"
-        >
-          <title>Chevron Down</title>
-          <path d="m6 9 6 6 6-6" />
-        </svg>
+        <ChevronDown class="h-4 w-4 opacity-50" aria-hidden="true" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -124,19 +113,7 @@ export const SelectItem = <T extends ValidComponent = "li">(
       {...rest}
     >
       <SelectPrimitive.ItemIndicator class="absolute right-2 flex h-4 w-4 items-center justify-center">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="h-4 w-4"
-        >
-          <title>Check</title>
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
+        <Check class="h-4 w-4" aria-hidden="true" />
       </SelectPrimitive.ItemIndicator>
       <SelectPrimitive.ItemLabel>{local.children}</SelectPrimitive.ItemLabel>
     </SelectPrimitive.Item>

--- a/src/lib/db/queries/groups.ts
+++ b/src/lib/db/queries/groups.ts
@@ -64,6 +64,11 @@ export interface GroupMemberCandidate {
   canAdd: boolean;
 }
 
+interface GroupMemberProfileSeed {
+  profileName?: string | null;
+  profileEmail?: string | null;
+}
+
 interface GroupMemberSearchProfile {
   userRef: string;
   profileName: string | null;
@@ -214,6 +219,38 @@ function mergeGroupMemberSearchProfile(
     profileName: existing.profileName ?? incoming.profileName,
     profileEmail: existing.profileEmail ?? incoming.profileEmail,
   };
+}
+
+async function upsertLocalGroupMemberProfile(
+  db: AnyDatabase,
+  userId: string,
+  profile: GroupMemberProfileSeed
+): Promise<void> {
+  if (!profile.profileName && !profile.profileEmail) {
+    return;
+  }
+
+  const existing = await getUserProfileRecord(db, userId);
+  const now = nowIso();
+
+  if (existing) {
+    await db
+      .update(userProfile)
+      .set({
+        name: existing.name ?? profile.profileName ?? undefined,
+        email: existing.email ?? profile.profileEmail ?? undefined,
+        lastModifiedAt: now,
+      })
+      .where(eq(userProfile.id, userId));
+    return;
+  }
+
+  await db.insert(userProfile).values({
+    id: userId,
+    name: profile.profileName ?? undefined,
+    email: profile.profileEmail ?? undefined,
+    lastModifiedAt: now,
+  });
 }
 
 function toGroupMemberCandidate(
@@ -851,7 +888,8 @@ export async function addGroupMember(
   groupId: string,
   actingUserId: string,
   memberUserId: string,
-  role: Exclude<GroupRole, "owner"> = "member"
+  role: Exclude<GroupRole, "owner"> = "member",
+  profile?: GroupMemberProfileSeed
 ): Promise<GroupMemberRow> {
   const access = await getGroupAccessForUser(db, groupId, actingUserId);
   if (!access.canManageMembership || !access.group) {
@@ -886,6 +924,7 @@ export async function addGroupMember(
       })
       .where(eq(groupMember.id, current.id))
       .returning();
+    await upsertLocalGroupMemberProfile(db, memberUserId, profile ?? {});
     await persistDb();
     return result[0];
   }
@@ -903,6 +942,7 @@ export async function addGroupMember(
   };
 
   const result = await db.insert(groupMember).values(newMembership).returning();
+  await upsertLocalGroupMemberProfile(db, memberUserId, profile ?? {});
   await persistDb();
   return result[0];
 }

--- a/src/routes/tunes/[id]/practice-history/index.tsx
+++ b/src/routes/tunes/[id]/practice-history/index.tsx
@@ -324,10 +324,38 @@ const PracticeHistoryPage: Component = () => {
                   class="border-dashed"
                   data-testid="practice-history-add-form"
                 >
-                  <CardHeader class="pb-3">
-                    <CardTitle class="text-base font-semibold">
-                      Add Practice Entry
-                    </CardTitle>
+                  <CardHeader class="space-y-3 pb-3">
+                    <header class="flex justify-between items-center w-full mb-4">
+                      <div class="flex flex-1 justify-start">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={handleCancelDraft}
+                          disabled={isSavingDraft()}
+                          data-testid="practice-history-discard-button"
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                      <div class="flex min-w-0 flex-1 justify-center px-3">
+                        <CardTitle class="text-center text-base font-semibold">
+                          Add Practice Entry
+                        </CardTitle>
+                      </div>
+                      <div class="flex flex-1 justify-end">
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={handleSaveDraft}
+                          disabled={isSavingDraft()}
+                          data-testid="practice-history-save-button"
+                        >
+                          <Save class="h-4 w-4" />
+                          <span>Save</span>
+                        </Button>
+                      </div>
+                    </header>
                     <CardDescription>
                       Manual backfill uses FSRS ratings and calculates the next
                       due date automatically.
@@ -382,29 +410,6 @@ const PracticeHistoryPage: Component = () => {
                           <option value={FSRS_QUALITY_MAP.EASY}>Easy</option>
                         </select>
                       </label>
-                    </div>
-
-                    <div class="flex flex-wrap justify-end gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={handleCancelDraft}
-                        disabled={isSavingDraft()}
-                        data-testid="practice-history-discard-button"
-                      >
-                        <span>Discard</span>
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        onClick={handleSaveDraft}
-                        disabled={isSavingDraft()}
-                        data-testid="practice-history-save-button"
-                      >
-                        <Save class="h-4 w-4" />
-                        <span>Save</span>
-                      </Button>
                     </div>
                   </CardContent>
                 </Card>

--- a/src/routes/tunes/[id]/practice-history/index.tsx
+++ b/src/routes/tunes/[id]/practice-history/index.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useLocation, useNavigate, useParams } from "@solidjs/router";
-import { CircleX, Plus, Save, Trash2, X } from "lucide-solid";
+import { Plus, Save, Trash2 } from "lucide-solid";
 import {
   type Component,
   createMemo,
@@ -293,7 +293,6 @@ const PracticeHistoryPage: Component = () => {
                   data-testid="practice-history-cancel-button"
                 >
                   <span>Cancel</span>
-                  <CircleX class="ml-0.5 h-4 w-4" />
                 </Button>
                 <Button
                   type="button"
@@ -302,8 +301,8 @@ const PracticeHistoryPage: Component = () => {
                   disabled={!canAddRecord()}
                   data-testid="practice-history-add-button"
                 >
+                  <Plus class="h-4 w-4" />
                   <span>Add</span>
-                  <Plus class="ml-0.5 h-4 w-4" />
                 </Button>
               </div>
             </div>
@@ -395,7 +394,6 @@ const PracticeHistoryPage: Component = () => {
                         data-testid="practice-history-discard-button"
                       >
                         <span>Discard</span>
-                        <X class="h-4 w-4" />
                       </Button>
                       <Button
                         type="button"
@@ -404,8 +402,8 @@ const PracticeHistoryPage: Component = () => {
                         disabled={isSavingDraft()}
                         data-testid="practice-history-save-button"
                       >
-                        <span>Save</span>
                         <Save class="h-4 w-4" />
+                        <span>Save</span>
                       </Button>
                     </div>
                   </CardContent>

--- a/src/routes/user-settings/catalog-sync.tsx
+++ b/src/routes/user-settings/catalog-sync.tsx
@@ -8,6 +8,7 @@
 
 import { type Component, createEffect, createSignal, Show } from "solid-js";
 import { type Genre, GenreMultiSelect } from "@/components/genre-selection";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth/AuthContext";
 import {
   getGenresWithSelection,
@@ -229,15 +230,15 @@ const CatalogSyncPage: Component = () => {
         />
 
         {/* Save button */}
-        <button
+        <Button
           type="button"
           onClick={handleSave}
           disabled={!isDirty() || isSubmitting()}
-          class="w-full px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-md transition-colors"
+          class="w-full"
           data-testid="settings-genre-save"
         >
           {isSubmitting() ? "Saving..." : "Save Changes"}
-        </button>
+        </Button>
 
         {/* Info box */}
       </Show>

--- a/src/routes/user-settings/goals.tsx
+++ b/src/routes/user-settings/goals.tsx
@@ -14,6 +14,7 @@
  * @module routes/user-settings/goals
  */
 
+import { Save } from "lucide-solid";
 import {
   type Component,
   createEffect,
@@ -125,9 +126,38 @@ const GoalForm: Component<{
 
   const set = <K extends keyof GoalFormState>(k: K, v: GoalFormState[K]) =>
     setForm((prev) => ({ ...prev, [k]: v }));
+  const formTitle = () => (props.initial ? "Edit Goal" : "Add Goal");
 
   return (
     <form onSubmit={handleSubmit} class="space-y-4">
+      <header class="flex justify-between items-center w-full mb-4">
+        <div class="flex flex-1 justify-start">
+          <Button type="button" onClick={props.onCancel} variant="outline">
+            Cancel
+          </Button>
+        </div>
+        <div class="flex min-w-0 flex-1 justify-center px-3">
+          <h3 class="text-center text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {formTitle()}
+          </h3>
+        </div>
+        <div class="flex flex-1 justify-end">
+          <Button type="submit" disabled={saving()}>
+            <Show
+              when={saving()}
+              fallback={
+                <>
+                  <Save class="h-4 w-4" />
+                  Save
+                </>
+              }
+            >
+              Saving…
+            </Show>
+          </Button>
+        </div>
+      </header>
+
       {/* Name */}
       <div>
         <label
@@ -241,16 +271,6 @@ const GoalForm: Component<{
       <Show when={error()}>
         <p class="text-sm text-red-600 dark:text-red-400">{error()}</p>
       </Show>
-
-      {/* Actions */}
-      <div class="flex w-full items-center justify-between gap-2">
-        <Button type="button" onClick={props.onCancel} variant="outline">
-          Cancel
-        </Button>
-        <Button type="submit" disabled={saving()}>
-          {saving() ? "Saving…" : props.submitLabel}
-        </Button>
-      </div>
     </form>
   );
 };

--- a/src/routes/user-settings/goals.tsx
+++ b/src/routes/user-settings/goals.tsx
@@ -21,6 +21,7 @@ import {
   For,
   Show,
 } from "solid-js";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth/AuthContext";
 import {
   type GoalRow,
@@ -242,21 +243,13 @@ const GoalForm: Component<{
       </Show>
 
       {/* Actions */}
-      <div class="flex items-center gap-2">
-        <button
-          type="submit"
-          disabled={saving()}
-          class="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 rounded-md transition-colors"
-        >
-          {saving() ? "Saving…" : props.submitLabel}
-        </button>
-        <button
-          type="button"
-          onClick={props.onCancel}
-          class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors"
-        >
+      <div class="flex w-full items-center justify-between gap-2">
+        <Button type="button" onClick={props.onCancel} variant="outline">
           Cancel
-        </button>
+        </Button>
+        <Button type="submit" disabled={saving()}>
+          {saving() ? "Saving…" : props.submitLabel}
+        </Button>
       </div>
     </form>
   );

--- a/src/routes/user-settings/goals.tsx
+++ b/src/routes/user-settings/goals.tsx
@@ -148,7 +148,7 @@ const GoalForm: Component<{
               fallback={
                 <>
                   <Save class="h-4 w-4" />
-                  Save
+                  {props.submitLabel}
                 </>
               }
             >

--- a/src/routes/user-settings/index.tsx
+++ b/src/routes/user-settings/index.tsx
@@ -8,6 +8,7 @@
  */
 
 import { A, useLocation, useNavigate } from "@solidjs/router";
+import { Menu, X } from "lucide-solid";
 import {
   type Component,
   createSignal,
@@ -159,20 +160,7 @@ const UserSettingsLayout: ParentComponent = (props) => {
                 aria-label="Toggle menu"
                 data-testid="settings-menu-toggle"
               >
-                <svg
-                  class="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <title>Menu</title>
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
-                </svg>
+                <Menu class="w-5 h-5" aria-hidden="true" />
               </button>
 
               <div>
@@ -195,21 +183,7 @@ const UserSettingsLayout: ParentComponent = (props) => {
               aria-label="Close settings"
               data-testid="settings-close-button"
             >
-              <svg
-                class="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-label="Close icon"
-              >
-                <title>Close</title>
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
+              <X class="w-5 h-5" aria-hidden="true" />
             </button>
           </div>
 

--- a/src/routes/user-settings/plugins.tsx
+++ b/src/routes/user-settings/plugins.tsx
@@ -852,7 +852,7 @@ const PluginsPage: Component = () => {
                   value={current().script}
                   onChange={(value) => updateDraft({ script: value })}
                   readOnly={!isOwner()}
-                  data-testid="plugin-script-editor"
+                  dataTestId="plugin-script-editor"
                 />
               </div>
 

--- a/src/routes/user-settings/plugins.tsx
+++ b/src/routes/user-settings/plugins.tsx
@@ -852,7 +852,7 @@ const PluginsPage: Component = () => {
                   value={current().script}
                   onChange={(value) => updateDraft({ script: value })}
                   readOnly={!isOwner()}
-                  dataTestId="plugin-script-editor"
+                  data-testid="plugin-script-editor"
                 />
               </div>
 

--- a/src/routes/user-settings/spaced-repetition.tsx
+++ b/src/routes/user-settings/spaced-repetition.tsx
@@ -8,6 +8,7 @@
  */
 
 import { type Component, createEffect, createSignal, Show } from "solid-js";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth/AuthContext";
 import {
   getSpacedRepetitionPrefs,
@@ -294,17 +295,18 @@ const SpacedRepetitionPage: Component = () => {
 
                 {/* Auto-Optimize Button */}
                 <div class="flex items-center gap-2 pt-2">
-                  <button
+                  <Button
                     type="button"
                     onClick={handleOptimizeParams}
                     disabled={isOptimizing()}
-                    class="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:bg-gray-100 disabled:cursor-not-allowed rounded-md transition-colors"
+                    variant="outline"
+                    size="sm"
                     data-testid="optimize-params-inline-button"
                   >
                     {isOptimizing()
                       ? "Optimizing..."
                       : "Auto-Optimize Parameters"}
-                  </button>
+                  </Button>
                   <span class="text-xs text-gray-500 dark:text-gray-400">
                     Automatically optimize weights based on your practice
                     history
@@ -345,15 +347,16 @@ const SpacedRepetitionPage: Component = () => {
               </div>
 
               {/* Additional Optimize Button */}
-              <button
+              <Button
                 type="button"
                 onClick={handleOptimizeParams}
                 disabled={isOptimizing()}
-                class="w-full px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:bg-gray-100 disabled:cursor-not-allowed rounded-md transition-colors"
+                variant="outline"
+                class="w-full"
                 data-testid="optimize-params-main-button"
               >
                 {isOptimizing() ? "Optimizing..." : "Optimize FSRS Parameters"}
-              </button>
+              </Button>
             </Show>
 
             {/* Success/Error Messages */}
@@ -374,18 +377,18 @@ const SpacedRepetitionPage: Component = () => {
             </Show>
 
             {/* Submit Button */}
-            <button
+            <Button
               type="submit"
               disabled={
                 !isDirty() ||
                 isSubmitting() ||
                 Object.keys(validationErrors()).length > 0
               }
-              class="w-full px-4 py-2.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-md transition-colors"
+              class="w-full"
               data-testid="spaced-rep-update-button"
             >
               {isSubmitting() ? "Saving..." : "Update"}
-            </button>
+            </Button>
           </form>
         </Show>
       </div>


### PR DESCRIPTION
## Summary
This draft PR captures the first pass of the UI refactor driven by `design/tunetrees-design-system.md` so CI can run against the current state of the work.

## What changed
- adds the initial design-system reference document
- upgrades `lucide-solid` and replaces raw inline SVG usage across the touched app UI surfaces
- normalizes a large set of shared toolbars, dialogs, selectors, and form action rows toward the current design-system rules
- updates shared UI primitives (`select`, `combobox`, `checkbox`, `alert-dialog`) to use Lucide icons consistently
- refines high-traffic screens including references, catalog, repertoire, practice, top navigation, settings, auth, and supporting utility components

## Validation
- `npm run lint && npm run check && npm run typecheck && npm run test:unit`

## Notes
- this is intentionally a draft because the broader design-system enforcement pass is not finished yet
- the current branch is focused on the first visual/system pass so we can get CI signal before continuing follow-up cleanup and normalization