### PR TITLE
🐛 Fix UI mobile bugs

### DIFF
--- a/design/tunetrees-design-system.md
+++ b/design/tunetrees-design-system.md
@@ -64,6 +64,8 @@ This index dictates exactly how common actions are handled across TuneTrees.
 | **Navigate Back** | "Back" | `Ghost` | `ChevronLeft` (<) | Top left of a screen (especially on mobile). |
 | **Modify Data** | "Edit" | `Outline` or `Ghost` | `SquarePen` (📝) | Next to the entity title, or inside a `⋮` menu. *(Note: Do NOT use standard `Pencil` as this implies full form/record edits).* |
 | **Permanently Erase** | "Delete" | `Destructive` | `Trash2` (🗑️) | Inside an overflow menu, or far left/bottom of an edit form. **Always requires a confirmation dialog.** |
+
+> **Inline Row Exception:** In dense list rows (e.g., Notes, References panels) where a filled `Destructive` button would be visually overwhelming, use `variant="ghost"` with `class="text-destructive hover:bg-destructive/10 hover:text-destructive"` for the delete icon button. This is the only approved deviation from `variant="destructive"` and applies only to icon-only buttons inside list items.
 | **Remove Relation** | "Remove" | `Outline` or `Ghost` | `Minus` or `X` | Use when taking a tune out of a playlist (the tune still exists in the DB). |
 | **View Details** | "Info" or "Details" | `Ghost` | `Info` (ℹ️) | Next to complex terms or inside list rows. |
 | **Options/Overflow**| None (Icon only) | `Ghost` | `MoreVertical` (⋮) | Far right of a row, card, or mobile toolbar. |

--- a/src/components/layout/AboutDialog.tsx
+++ b/src/components/layout/AboutDialog.tsx
@@ -120,7 +120,7 @@ export const AboutDialog: Component<AboutDialogProps> = (props) => {
           </div>
         </AlertDialogHeader>
 
-        <div class="py-4 pb-6">
+        <div class="flex-1 overflow-y-auto min-h-0 py-4 pb-6">
           <dl class="space-y-3 text-sm">
             <div class="flex justify-between">
               <dt class="font-medium text-gray-600 dark:text-gray-400">

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -1,8 +1,8 @@
 import {
-  Edit,
   GripVertical,
   Plus,
   Save,
+  SquarePen,
   StickyNote,
   Trash2,
   X,
@@ -16,6 +16,7 @@ import {
   onCleanup,
   Show,
 } from "solid-js";
+import { Button } from "@/components/ui/button";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { useCurrentTune } from "@/lib/context/CurrentTuneContext";
 import {
@@ -518,31 +519,35 @@ export const NotesPanel: Component = () => {
                     when={isEditing()}
                     fallback={
                       <Show when={canManageNote(note)}>
-                        <div class="flex gap-0.5">
-                          <button
+                        <div class="flex gap-1">
+                          <Button
                             type="button"
                             onClick={() => {
                               setEditingNoteId(note.id);
                               setEditingContent(note.noteText || "");
                             }}
-                            class={`inline-flex items-center gap-0.5 ${fontClasses().textSmall} px-1.5 py-0.5 text-blue-600 dark:text-blue-400 hover:bg-blue-50/50 dark:hover:bg-blue-900/30 rounded-sm transition-colors`}
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8 text-primary/70"
                             title="Edit note"
+                            aria-label="Edit note"
                             data-testid={`note-edit-button-${note.id}`}
                           >
-                            Edit
-                            <Edit class={fontClasses().iconSmall} />
-                          </button>
+                            <SquarePen class="w-4 h-4" />
+                          </Button>
 
-                          <button
+                          <Button
                             type="button"
                             onClick={() => requestDeleteNote(note.id)}
-                            class={`inline-flex items-center gap-0.5 ${fontClasses().textSmall} px-1.5 py-0.5 text-red-600 dark:text-red-400 hover:bg-red-50/50 dark:hover:bg-red-900/30 rounded-sm transition-colors`}
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8 text-destructive hover:bg-destructive/10 hover:text-destructive"
                             title="Delete note"
+                            aria-label="Delete note"
                             data-testid={`note-delete-button-${note.id}`}
                           >
-                            Delete
-                            <Trash2 class={fontClasses().iconSmall} />
-                          </button>
+                            <Trash2 class="w-4 h-4" />
+                          </Button>
                         </div>
                       </Show>
                     }

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -465,7 +465,7 @@ export const NotesPanel: Component = () => {
 
             return (
               <li
-                class={`p-2 bg-white/50 dark:bg-gray-800/50 rounded border transition-all ${
+                class={`group p-2 bg-white/50 dark:bg-gray-800/50 rounded border transition-all ${
                   draggedNoteId() === note.id
                     ? "opacity-50 border-gray-400/50 dark:border-gray-500/50"
                     : dragOverNoteId() === note.id
@@ -519,7 +519,7 @@ export const NotesPanel: Component = () => {
                     when={isEditing()}
                     fallback={
                       <Show when={canManageNote(note)}>
-                        <div class="flex gap-1">
+                        <div class="flex gap-1 opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity">
                           <Button
                             type="button"
                             onClick={() => {
@@ -528,12 +528,12 @@ export const NotesPanel: Component = () => {
                             }}
                             variant="ghost"
                             size="icon"
-                            class="h-8 w-8 text-primary/70"
+                            class="h-8 w-8 !text-blue-600 hover:!text-blue-700 dark:!text-blue-400 dark:hover:!text-blue-300"
                             title="Edit note"
                             aria-label="Edit note"
                             data-testid={`note-edit-button-${note.id}`}
                           >
-                            <SquarePen class="w-4 h-4" />
+                            <SquarePen class="h-4 w-4 !text-blue-600 dark:!text-blue-400" />
                           </Button>
 
                           <Button
@@ -541,12 +541,12 @@ export const NotesPanel: Component = () => {
                             onClick={() => requestDeleteNote(note.id)}
                             variant="ghost"
                             size="icon"
-                            class="h-8 w-8 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                            class="h-8 w-8 !text-red-600 hover:!text-red-700 hover:bg-destructive/10 dark:!text-red-400 dark:hover:!text-red-300"
                             title="Delete note"
                             aria-label="Delete note"
                             data-testid={`note-delete-button-${note.id}`}
                           >
-                            <Trash2 class="w-4 h-4" />
+                            <Trash2 class="h-4 w-4 !text-red-600 dark:!text-red-400" />
                           </Button>
                         </div>
                       </Show>

--- a/src/components/notes/NotesPanel.tsx
+++ b/src/components/notes/NotesPanel.tsx
@@ -533,7 +533,7 @@ export const NotesPanel: Component = () => {
                             aria-label="Edit note"
                             data-testid={`note-edit-button-${note.id}`}
                           >
-                            <SquarePen class="h-4 w-4 !text-blue-600 dark:!text-blue-400" />
+                            <SquarePen class="h-4 w-4" />
                           </Button>
 
                           <Button
@@ -546,7 +546,7 @@ export const NotesPanel: Component = () => {
                             aria-label="Delete note"
                             data-testid={`note-delete-button-${note.id}`}
                           >
-                            <Trash2 class="h-4 w-4 !text-red-600 dark:!text-red-400" />
+                            <Trash2 class="h-4 w-4" />
                           </Button>
                         </div>
                       </Show>

--- a/src/components/references/ReferenceList.tsx
+++ b/src/components/references/ReferenceList.tsx
@@ -261,7 +261,7 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
                   aria-label="Edit reference"
                   data-testid={`reference-edit-button-${itemProps.reference.id}`}
                 >
-                  <SquarePen class="h-4 w-4 !text-blue-600 dark:!text-blue-400" />
+                  <SquarePen class="h-4 w-4" />
                 </Button>
               </Show>
 
@@ -276,7 +276,7 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
                   aria-label="Delete reference"
                   data-testid={`reference-delete-button-${itemProps.reference.id}`}
                 >
-                  <Trash2 class="h-4 w-4 !text-red-600 dark:!text-red-400" />
+                  <Trash2 class="h-4 w-4" />
                 </Button>
               </Show>
             </div>

--- a/src/components/references/ReferenceList.tsx
+++ b/src/components/references/ReferenceList.tsx
@@ -256,12 +256,12 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
                   onClick={() => props.onEdit!(itemProps.reference)}
                   variant="ghost"
                   size="icon"
-                  class="h-7 w-7 text-primary/70"
+                  class="h-7 w-7 !text-blue-600 hover:!text-blue-700 dark:!text-blue-400 dark:hover:!text-blue-300"
                   title="Edit reference"
                   aria-label="Edit reference"
                   data-testid={`reference-edit-button-${itemProps.reference.id}`}
                 >
-                  <SquarePen class="w-4 h-4" />
+                  <SquarePen class="h-4 w-4 !text-blue-600 dark:!text-blue-400" />
                 </Button>
               </Show>
 
@@ -271,12 +271,12 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
                   onClick={() => props.onDelete!(itemProps.reference.id)}
                   variant="ghost"
                   size="icon"
-                  class="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  class="h-7 w-7 !text-red-600 hover:!text-red-700 hover:bg-destructive/10 dark:!text-red-400 dark:hover:!text-red-300"
                   title="Delete reference"
                   aria-label="Delete reference"
                   data-testid={`reference-delete-button-${itemProps.reference.id}`}
                 >
-                  <Trash2 class="w-4 h-4" />
+                  <Trash2 class="h-4 w-4 !text-red-600 dark:!text-red-400" />
                 </Button>
               </Show>
             </div>

--- a/src/components/references/ReferenceList.tsx
+++ b/src/components/references/ReferenceList.tsx
@@ -235,17 +235,53 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
 
       {/* Content */}
       <div class="flex-1 min-w-0">
-        {/* Title or URL */}
-        <button
-          type="button"
-          onClick={() => handleOpenReference(itemProps.reference)}
-          class="text-left w-full text-blue-600 dark:text-blue-400 hover:underline font-medium break-words"
-          title="Open reference"
-          aria-label="Open reference"
-          data-testid={`reference-link-${itemProps.reference.id}`}
-        >
-          {getReferencePrimaryLabel(itemProps.reference)}
-        </button>
+        {/* Title row with inline actions */}
+        <div class="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => handleOpenReference(itemProps.reference)}
+            class="flex-1 min-w-0 text-left text-blue-600 dark:text-blue-400 hover:underline font-medium break-words"
+            title="Open reference"
+            aria-label="Open reference"
+            data-testid={`reference-link-${itemProps.reference.id}`}
+          >
+            {getReferencePrimaryLabel(itemProps.reference)}
+          </button>
+
+          <Show when={showActions() && canEditReference(itemProps.reference)}>
+            <div class="flex gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity">
+              <Show when={props.onEdit}>
+                <Button
+                  type="button"
+                  onClick={() => props.onEdit!(itemProps.reference)}
+                  variant="ghost"
+                  size="icon"
+                  class="h-7 w-7 text-primary/70"
+                  title="Edit reference"
+                  aria-label="Edit reference"
+                  data-testid={`reference-edit-button-${itemProps.reference.id}`}
+                >
+                  <SquarePen class="w-4 h-4" />
+                </Button>
+              </Show>
+
+              <Show when={props.onDelete}>
+                <Button
+                  type="button"
+                  onClick={() => props.onDelete!(itemProps.reference.id)}
+                  variant="ghost"
+                  size="icon"
+                  class="h-7 w-7 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  title="Delete reference"
+                  aria-label="Delete reference"
+                  data-testid={`reference-delete-button-${itemProps.reference.id}`}
+                >
+                  <Trash2 class="w-4 h-4" />
+                </Button>
+              </Show>
+            </div>
+          </Show>
+        </div>
 
         {/* Type label */}
         <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
@@ -288,41 +324,6 @@ export const ReferenceList: Component<ReferenceListProps> = (props) => {
           </button>
         </Show>
       </div>
-
-      {/* Actions */}
-      <Show when={showActions() && canEditReference(itemProps.reference)}>
-        <div class="flex gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-          <Show when={props.onEdit}>
-            <Button
-              type="button"
-              onClick={() => props.onEdit!(itemProps.reference)}
-              variant="ghost"
-              size="icon"
-              class="h-8 w-8 text-primary"
-              title="Edit reference"
-              aria-label="Edit reference"
-              data-testid={`reference-edit-button-${itemProps.reference.id}`}
-            >
-              <SquarePen class="w-4 h-4" />
-            </Button>
-          </Show>
-
-          <Show when={props.onDelete}>
-            <Button
-              type="button"
-              onClick={() => props.onDelete!(itemProps.reference.id)}
-              variant="ghost"
-              size="icon"
-              class="h-8 w-8 text-destructive hover:bg-destructive/10 hover:text-destructive"
-              title="Delete reference"
-              aria-label="Delete reference"
-              data-testid={`reference-delete-button-${itemProps.reference.id}`}
-            >
-              <Trash2 class="w-4 h-4" />
-            </Button>
-          </Show>
-        </div>
-      </Show>
     </li>
   );
 


### PR DESCRIPTION
Fixes https://github.com/sboagy/tunetrees/issues/577
Fixes https://github.com/sboagy/tunetrees/issues/579


```
The fix is applied. The issue was that the middle content area didn't have `flex-1 overflow-y-auto min-h-0`, so on smaller screens the content pushed the footer button row out of the visible area and it got clipped by `overflow-hidden` on the dialog.

The change adds `flex-1 overflow-y-auto min-h-0` to the middle `<div>`:
- **`flex-1`** — takes remaining space after header and footer
- **`overflow-y-auto`** — scrolls when content overflows
- **`min-h-0`** — allows the flex child to shrink below its intrinsic content height (critical for scrolling to actually work in a flex column)

This ensures the footer with the "Check for Update" / "Update Now" button always stays visible at the bottom of the dialog, with the credits section scrolling independently above it.