### PR TITLE
Add rhythm patterns schema and playback support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rhythm-accomp.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rhythm-accomp.md
@@ -1,0 +1,38 @@
+## Summary
+
+This PR delivers one mergeable slice of #607.
+
+Related to #607.
+
+Note: this PR advances #607 but does not close it.
+
+## Advances #607
+
+- 
+- 
+
+## Not in this PR
+
+- 
+- 
+
+## Merge safety
+
+This is safe to merge now because:
+- 
+- 
+
+## Review focus
+
+- 
+- 
+
+## Validation
+
+- `npm run lint && npm run check && npm run typecheck && npm run test:unit`
+- 
+
+## Notes
+
+- Do not use `Closes #607`, `Fixes #607`, or `Resolves #607` in this PR unless it actually completes the umbrella issue.
+- Prefer wording like `Related to #607`, `Part of #607`, or `Advances #607` for incremental PRs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ name: CI - Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
     # <-- This is your manual trigger
 
@@ -79,7 +79,7 @@ jobs:
     name: Run Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [ quality ]
+    needs: [quality]
     environment: tunetrees_ci_env
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -112,12 +112,12 @@ jobs:
   test:
     name: Run Playwright Tests
     runs-on: ubuntu-latest
-    needs: [ quality ]
+    needs: [quality]
 
     strategy:
       fail-fast: false
       matrix:
-        shard: [ 1, 2, 3, 4 ]
+        shard: [1, 2, 3, 4]
 
     timeout-minutes: 60
     environment: tunetrees_ci_env
@@ -422,7 +422,7 @@ jobs:
     name: Run PWA Offline Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [ quality ]
+    needs: [quality]
     environment: tunetrees_ci_env
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -738,7 +738,7 @@ jobs:
   merge-reports:
     name: Merge Playwright Reports
     if: always()
-    needs: [ test, test-pwa-offline ]
+    needs: [test, test-pwa-offline]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout TuneTrees
@@ -811,7 +811,7 @@ jobs:
   deploy:
     name: Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
-    needs: [ test-unit, test, test-pwa-offline ]
+    needs: [test-unit, test, test-pwa-offline]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/tt_rz_refactor')
     environment: tunetrees_ci_env
@@ -858,7 +858,7 @@ jobs:
   deploy-worker:
     name: Deploy Cloudflare Worker
     runs-on: ubuntu-latest
-    needs: [ test-unit, test, test-pwa-offline ]
+    needs: [test-unit, test, test-pwa-offline]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' ||
       github.ref == 'refs/heads/tt_rz_refactor')
     environment: tunetrees_ci_env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,12 +362,9 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright Browsers
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        # A cache hit does not guarantee every required browser binary is
+        # present for the current Playwright package, so always verify/install.
         run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright System Dependencies
-        if: steps.cache-playwright.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
 
       - name: Setup Cloudflare Worker
         run: |
@@ -660,12 +657,9 @@ jobs:
           echo "DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres" >> .dev.vars
 
       - name: Install Playwright Browsers
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        # A cache hit does not guarantee every required browser binary is
+        # present for the current Playwright package, so always verify/install.
         run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright System Dependencies
-        if: steps.cache-playwright.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
 
       - name: Build PWA
         run: |

--- a/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql
+++ b/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `genre_tune_type` ADD COLUMN `default_bpm` integer;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `rhythm_patterns` (
+  `id` text PRIMARY KEY NOT NULL,
+  `genre_id` text NOT NULL REFERENCES `genre`(`id`),
+  `tune_type_id` text NOT NULL REFERENCES `tune_type`(`id`),
+  `name` text NOT NULL,
+  `part_target` text DEFAULT '*',
+  `abc_string` text NOT NULL,
+  `is_default` integer DEFAULT 0 NOT NULL,
+  `premium_audio_url` text
+);

--- a/drizzle/schema-sqlite.generated.ts
+++ b/drizzle/schema-sqlite.generated.ts
@@ -115,6 +115,7 @@ export const genreTuneType = sqliteTable(
     tuneTypeId: text("tune_type_id")
       .notNull()
       .references(() => tuneType.id),
+    defaultBpm: integer("default_bpm"),
   },
   (t) => [primaryKey({ columns: [t.genreId, t.tuneTypeId] })]
 );
@@ -424,6 +425,24 @@ export const repertoireTune = sqliteTable(
   },
   (t) => [primaryKey({ columns: [t.repertoireRef, t.tuneRef] })]
 );
+
+export const rhythmPatterns = sqliteTable("rhythm_patterns", {
+  id: text("id")
+    .notNull()
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  genreId: text("genre_id")
+    .notNull()
+    .references(() => genre.id),
+  tuneTypeId: text("tune_type_id")
+    .notNull()
+    .references(() => tuneType.id),
+  name: text("name").notNull(),
+  partTarget: text("part_target").default("*"),
+  abcString: text("abc_string").notNull(),
+  isDefault: integer("is_default").notNull().default(0),
+  premiumAudioUrl: text("premium_audio_url"),
+});
 
 export const setlist = sqliteTable(
   "setlist",

--- a/e2e/helpers/practice-scenarios.ts
+++ b/e2e/helpers/practice-scenarios.ts
@@ -2194,6 +2194,11 @@ export async function setupForSetlistTestsParallel(
     window.__ttTestApi?.setTestUserId(userId);
   }, user.userId);
 
+  // __ttTestApi can attach before the app's local DB bootstrap and initial
+  // sync have fully settled. Wait for the existing sync-ready signal before
+  // using test API helpers that call into ensureDb()/initializeDb().
+  await waitForSyncComplete(page);
+
   const seededPublicTunes = opts.publicTunes?.length
     ? await page.evaluate(
         async ({ tunes }) => {

--- a/e2e/helpers/setlist-test-helpers.ts
+++ b/e2e/helpers/setlist-test-helpers.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { expect, type Page } from "@playwright/test";
 import type { TuneTreesPage } from "../page-objects/TuneTreesPage";
 import { setupForSetlistTestsParallel } from "./practice-scenarios";
@@ -68,18 +69,25 @@ export async function setupLibraryOnlySetlistsScenario(
   page: Page,
   testUser: TestUser
 ) {
-  return setupForSetlistTestsParallel(page, testUser, {
+  const libraryTuneSetName = `${SETLIST_TITLES.defaultTuneSet} ${randomUUID().slice(0, 8)}`;
+
+  const scenario = await setupForSetlistTestsParallel(page, testUser, {
     repertoireTunes: [],
     publicTunes: PUBLIC_TUNE_TITLES.map((title) => ({ title })),
     sharedTuneSets: [
       {
-        name: SETLIST_TITLES.defaultTuneSet,
+        name: libraryTuneSetName,
         description: "Opening set for regression coverage",
         tuneIndexes: [1, 2],
       },
     ],
     setlists: [],
   });
+
+  return {
+    ...scenario,
+    libraryTuneSetName,
+  };
 }
 
 export async function setupNamedEmptySetlistScenario(

--- a/e2e/page-objects/TuneTreesPage.ts
+++ b/e2e/page-objects/TuneTreesPage.ts
@@ -3106,6 +3106,26 @@ export class TuneTreesPage {
     await this.revealToolbarAction(tab, action);
   }
 
+  private async clickVisibleToolbarAction(action: Locator): Promise<void> {
+    await action.evaluateAll((elements) => {
+      const visibleEnabledElement = elements.find((element) => {
+        const htmlElement = element as HTMLElement;
+        const buttonElement = element as HTMLButtonElement;
+        return (
+          htmlElement.getClientRects().length > 0 &&
+          !buttonElement.disabled &&
+          element.getAttribute("aria-disabled") !== "true"
+        );
+      }) as HTMLElement | undefined;
+
+      if (!visibleEnabledElement) {
+        throw new Error("No visible enabled toolbar action found");
+      }
+
+      visibleEnabledElement.click();
+    });
+  }
+
   private async clickToolbarAction(
     tab: "catalog" | "repertoire" | "practice",
     action: Locator,
@@ -3128,7 +3148,7 @@ export class TuneTreesPage {
           try {
             await action.click({ timeout: 1000, force: true });
           } catch {
-            await action.dispatchEvent("click");
+            await this.clickVisibleToolbarAction(action);
           }
         }
 
@@ -3138,6 +3158,13 @@ export class TuneTreesPage {
         return;
       } catch (error) {
         lastError = error;
+
+        // If the page has already been torn down, the original failure is the
+        // useful signal. Retrying via waitForTimeout only masks it.
+        if (this.page.isClosed()) {
+          break;
+        }
+
         await this.page.waitForTimeout(150);
       }
     }

--- a/e2e/setup/auth.setup.ts
+++ b/e2e/setup/auth.setup.ts
@@ -603,6 +603,80 @@ async function resetTunetreesUserData(): Promise<void> {
   }
 }
 
+/**
+ * Recreate any missing named test auth users in the local Supabase auth store.
+ *
+ * A full `supabase db reset --local` wipes auth.users, but our Playwright auth
+ * bootstrap logs in by password and assumes those shared users already exist.
+ * Recreating them here keeps `db:local:reset` self-healing even after a full
+ * local reset, without depending on an external shell script being present.
+ */
+async function ensureNamedTestAuthUsers(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  adminClient: ReturnType<typeof createClient<any>>
+): Promise<void> {
+  const existingUserIds = new Set<string>();
+  const existingEmails = new Set<string>();
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const { data, error } = await adminClient.auth.admin.listUsers({
+      page,
+      perPage,
+    });
+
+    if (error) {
+      throw new Error(
+        `[auth.setup] Failed to list auth users while ensuring named test users: ${error.message}`
+      );
+    }
+
+    const users = data?.users ?? [];
+    for (const user of users) {
+      if (user.id) {
+        existingUserIds.add(user.id);
+      }
+      if (user.email) {
+        existingEmails.add(user.email.toLowerCase());
+      }
+    }
+
+    if (users.length < perPage) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  const password = getRequiredTestPassword();
+
+  for (const testUser of Object.values(TEST_USERS)) {
+    if (
+      existingUserIds.has(testUser.userId) ||
+      existingEmails.has(testUser.email.toLowerCase())
+    ) {
+      continue;
+    }
+
+    const { error } = await adminClient.auth.admin.createUser({
+      id: testUser.userId,
+      email: testUser.email,
+      password,
+      email_confirm: true,
+      user_metadata: { name: testUser.name },
+    });
+
+    if (error) {
+      throw new Error(
+        `[auth.setup] Failed to recreate auth user ${testUser.email}: ${error.message}`
+      );
+    }
+
+    console.log(`  ✅ Recreated auth user ${testUser.email}`);
+  }
+}
+
 // -- main setup test ----------------------------------------------------------
 
 /**
@@ -626,6 +700,21 @@ setup("authenticate all test users", async ({ browser }) => {
     console.log("🗑️  RESET_DB=true — clearing TuneTrees user data in Supabase…");
     await resetTunetreesUserData();
     console.log("✅ TuneTrees user data cleared");
+
+    const resetSupabaseUrl = process.env.VITE_SUPABASE_URL;
+    const resetServiceRoleKey = resolveResetServiceRoleKey();
+
+    if (!resetSupabaseUrl) {
+      throw new Error(
+        "[auth.setup] RESET_DB=true requires VITE_SUPABASE_URL to be set."
+      );
+    }
+
+    const adminClient = createClient(resetSupabaseUrl, resetServiceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    await ensureNamedTestAuthUsers(adminClient);
   } else {
     console.log("ℹ️  Skipping DB reset (set RESET_DB=true to clear test data)");
   }

--- a/e2e/tests/catalog-add-to-repertoire.spec.ts
+++ b/e2e/tests/catalog-add-to-repertoire.spec.ts
@@ -52,6 +52,10 @@ test.describe
     test("should keep Add To Repertoire disabled until rows are selected", async ({
       page,
     }) => {
+      const visibleAddToRepertoireButton = page
+        .locator('[data-testid="catalog-add-to-repertoire-button"]:visible')
+        .first();
+
       await page.waitForSelector('[data-testid="tunes-grid-catalog"]', {
         timeout: 10000,
       });
@@ -61,8 +65,7 @@ test.describe
       });
       await expect
         .poll(
-          () =>
-            ttPage.catalogAddToRepertoireButton.isDisabled().catch(() => false),
+          () => visibleAddToRepertoireButton.isDisabled().catch(() => false),
           {
             timeout: 5000,
             intervals: [100, 250, 500, 1000],
@@ -88,9 +91,7 @@ test.describe
               addToRepertoire: true,
               tab: "catalog",
             });
-            return ttPage.catalogAddToRepertoireButton
-              .isEnabled()
-              .catch(() => false);
+            return visibleAddToRepertoireButton.isEnabled().catch(() => false);
           },
           {
             timeout: 5000,

--- a/e2e/tests/scheduling-003-repeated-easy.spec.ts
+++ b/e2e/tests/scheduling-003-repeated-easy.spec.ts
@@ -332,6 +332,10 @@ test.describe("SCHEDULING-003: Repeated Easy Evaluations", () => {
           timeout: 20000,
         });
 
+        // After time-travel reloads and re-login redirects, land back on the
+        // Practice route before refreshing queue state or toggling flashcards.
+        await ttPage.navigateToTab("practice");
+
         // After reload, ensure we pull any data that was flushed server-side
         await runTestHook(page, "__forceSyncDownForTest");
         await page.waitForLoadState("networkidle", { timeout: 15000 });

--- a/e2e/tests/setlist-003-library-add.spec.ts
+++ b/e2e/tests/setlist-003-library-add.spec.ts
@@ -21,12 +21,14 @@ test.describe
     test.setTimeout(60000);
 
     let ttPage: TuneTreesPage;
+    let libraryTuneSetName = SETLIST_TITLES.defaultTuneSet;
 
     test.beforeEach(async ({ page, testUser }, testInfo) => {
       test.setTimeout(Math.max(testInfo.timeout, 60000));
       ttPage = new TuneTreesPage(page);
 
       const scenario = await setupLibraryOnlySetlistsScenario(page, testUser);
+      libraryTuneSetName = scenario.libraryTuneSetName;
       await ttPage.navigateToSetlistsTab();
       await ttPage.selectSetlistsGroup(scenario.groupName);
       await enterSetlistsCreateMode(ttPage, page);
@@ -43,9 +45,9 @@ test.describe
           )
           .first()
       ).toBeVisible({ timeout: 10000 });
-      await ttPage.searchSetlistsLibrary(SETLIST_TITLES.defaultTuneSet);
+      await ttPage.searchSetlistsLibrary(libraryTuneSetName);
       await expect(
-        ttPage.getSetlistsLibrarySetRow(SETLIST_TITLES.defaultTuneSet)
+        ttPage.getSetlistsLibrarySetRow(libraryTuneSetName)
       ).toBeVisible({ timeout: 10000 });
     });
 
@@ -59,13 +61,13 @@ test.describe
           .first()
       ).toBeVisible({ timeout: 10000 });
       await expect(
-        ttPage.getSetlistsLibrarySetRow(SETLIST_TITLES.defaultTuneSet)
+        ttPage.getSetlistsLibrarySetRow(libraryTuneSetName)
       ).toHaveCount(0);
 
-      await ttPage.searchSetlistsLibrary(SETLIST_TITLES.defaultTuneSet);
+      await ttPage.searchSetlistsLibrary(libraryTuneSetName);
       await ttPage.setSetlistsLibraryFilter("tune_set");
       await expect(
-        ttPage.getSetlistsLibrarySetRow(SETLIST_TITLES.defaultTuneSet)
+        ttPage.getSetlistsLibrarySetRow(libraryTuneSetName)
       ).toBeVisible({ timeout: 10000 });
       await expect(
         ttPage.getSetlistsLibraryRow(SETLIST_TITLES.alpha)
@@ -111,9 +113,9 @@ test.describe
         )
         .first();
       await ttPage.setRowSelected(firstLibraryRow, true);
-      await ttPage.searchSetlistsLibrary(SETLIST_TITLES.defaultTuneSet);
+      await ttPage.searchSetlistsLibrary(libraryTuneSetName);
       await ttPage.setRowSelected(
-        ttPage.getSetlistsLibrarySetRow(SETLIST_TITLES.defaultTuneSet),
+        ttPage.getSetlistsLibrarySetRow(libraryTuneSetName),
         true
       );
 
@@ -127,9 +129,9 @@ test.describe
         )
         .first();
       await ttPage.setRowSelected(firstLibraryRow, true);
-      await ttPage.searchSetlistsLibrary(SETLIST_TITLES.defaultTuneSet);
+      await ttPage.searchSetlistsLibrary(libraryTuneSetName);
       await ttPage.setRowSelected(
-        ttPage.getSetlistsLibrarySetRow(SETLIST_TITLES.defaultTuneSet),
+        ttPage.getSetlistsLibrarySetRow(libraryTuneSetName),
         true
       );
 
@@ -138,9 +140,9 @@ test.describe
         .waitForLoadState("networkidle", { timeout: 15000 })
         .catch(() => undefined);
 
-      await expect(
-        ttPage.getSetlistsEditorRow(SETLIST_TITLES.defaultTuneSet)
-      ).toBeVisible({ timeout: 10000 });
+      await expect(ttPage.getSetlistsEditorRow(libraryTuneSetName)).toBeVisible(
+        { timeout: 10000 }
+      );
       await expect(ttPage.setlistsAddSelectedButton).not.toContainText("(2)");
     });
 
@@ -159,7 +161,7 @@ test.describe
 
     test("C7. should not show duplicate tunes in the All filter", async () => {
       await ttPage.setSetlistsLibraryFilter("all");
-      await ttPage.searchSetlistsLibrary(SETLIST_TITLES.defaultTuneSet);
+      await ttPage.searchSetlistsLibrary(libraryTuneSetName);
 
       await expect(
         ttPage.setlistsLibraryGrid.locator(

--- a/oosync.codegen.config.json
+++ b/oosync.codegen.config.json
@@ -57,6 +57,7 @@
       "genre": "catalog",
       "tune_type": "catalog",
       "genre_tune_type": "catalog",
+      "rhythm_patterns": "catalog",
       "user_profile": "user",
       "instrument": "catalog",
       "prefs_scheduling_options": "user",

--- a/oosync.codegen.config.json
+++ b/oosync.codegen.config.json
@@ -18,8 +18,8 @@
     "dbVersionKeyPrefix": "tunetrees-db-version",
     "outboxBackupKeyPrefix": "tunetrees-outbox-backup",
     "lastSyncTimestampKeyPrefix": "TT_LAST_SYNC_TIMESTAMP",
-    "schemaVersion": "2.0.9-rename-program-to-setlist",
-    "databaseVersion": 18,
+    "schemaVersion": "2.0.10-add-rhythm-patterns",
+    "databaseVersion": 19,
     "migrationDirectory": "drizzle/migrations/sqlite",
     "migrationFiles": [
       "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",
@@ -40,7 +40,8 @@
       "/drizzle/migrations/sqlite/0015_add_groups_and_tune_sets.sql",
       "/drizzle/migrations/sqlite/0016_add_programs.sql",
       "/drizzle/migrations/sqlite/0017_fix_ordered_item_conflict_targets.sql",
-      "/drizzle/migrations/sqlite/0018_rename_program_to_setlist.sql"
+      "/drizzle/migrations/sqlite/0018_rename_program_to_setlist.sql",
+      "/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql"
     ],
     "forceResetQueryParams": [
       { "key": "reset", "value": "true" },

--- a/shared/generated/sync/table-meta.generated.ts
+++ b/shared/generated/sync/table-meta.generated.ts
@@ -32,6 +32,7 @@ export const SYNCABLE_TABLES = [
   "reference",
   "repertoire",
   "repertoire_tune",
+  "rhythm_patterns",
   "setlist",
   "setlist_item",
   "tab_group_main_state",
@@ -131,6 +132,8 @@ export const TABLE_REGISTRY_CORE: Record<SyncableTableName, TableMetaCore> = {
     supportsIncremental: false,
     hasDeletedFlag: false,
     columnDescriptions: {
+      default_bpm:
+        "The baseline tempo (Beats/Quarter-notes Per Minute) for this specific genre and tune type combination (e.g., 115 for an ITRAD JigD).",
       genre_id: "Reference to the genre.",
       tune_type_id: "Reference to the tune type.",
     },
@@ -379,6 +382,29 @@ export const TABLE_REGISTRY_CORE: Record<SyncableTableName, TableMetaCore> = {
       scheduled: "Manual schedule override for next review.",
       sync_version: "Sync version for conflict resolution.",
       tune_ref: "Reference to the tune.",
+    },
+  },
+  rhythm_patterns: {
+    primaryKey: "id",
+    uniqueKeys: null,
+    timestamps: [],
+    booleanColumns: ["is_default"],
+    supportsIncremental: false,
+    hasDeletedFlag: false,
+    columnDescriptions: {
+      abc_string:
+        "The 2-bar or 4-bar ABC notation string used by the abcjs TimingCallbacks engine to generate the metronome loop (e.g., |: C2 c C c c :|).",
+      genre_id: "Foreign key component referencing the genre (e.g., ITRAD).",
+      id: "Unique identifier for the rhythm pattern variation.",
+      is_default:
+        "If true, this is the baseline Smart Metronome pattern that loads automatically when the user selects this genre/tune-type combination.",
+      name: 'A human-readable description for the UI dropdown (e.g., "Basic Rolling", "Driving Backbeat").',
+      part_target:
+        'Specifies which structural part this pattern targets. "*" or NULL applies to the whole tune, "A" applies only to the A part, "B" to the B part, allowing the groove to change mid-tune.',
+      premium_audio_url:
+        "Optional URL to a pre-recorded audio loop (e.g., an MP3 hosted on Cloudflare R2). If present, the UI logic should prioritize streaming this file over generating the ABC string.",
+      tune_type_id:
+        "Foreign key component referencing the tune type (e.g., JigD).",
     },
   },
   setlist: {

--- a/shared/table-meta.ts
+++ b/shared/table-meta.ts
@@ -310,7 +310,7 @@ const TABLE_EXTRAS: Record<
     },
   },
   rhythm_patterns: {
-    changeCategory: null,
+    changeCategory: "catalog",
     columnDescriptions: {
       abc_string:
         "The 2-bar or 4-bar ABC notation string used by the abcjs TimingCallbacks engine to generate the metronome loop (e.g., |: C2 c C c c :|).",

--- a/shared/table-meta.ts
+++ b/shared/table-meta.ts
@@ -115,6 +115,8 @@ const TABLE_EXTRAS: Record<
   genre_tune_type: {
     changeCategory: "catalog",
     columnDescriptions: {
+      default_bpm:
+        "The baseline tempo (Beats/Quarter-notes Per Minute) for this specific genre and tune type combination (e.g., 115 for an ITRAD JigD).",
       genre_id: "Reference to the genre.",
       tune_type_id: "Reference to the tune type.",
     },
@@ -305,6 +307,24 @@ const TABLE_EXTRAS: Record<
       scheduled: "Manual schedule override for next review.",
       sync_version: "Sync version for conflict resolution.",
       tune_ref: "Reference to the tune.",
+    },
+  },
+  rhythm_patterns: {
+    changeCategory: null,
+    columnDescriptions: {
+      abc_string:
+        "The 2-bar or 4-bar ABC notation string used by the abcjs TimingCallbacks engine to generate the metronome loop (e.g., |: C2 c C c c :|).",
+      genre_id: "Foreign key component referencing the genre (e.g., ITRAD).",
+      id: "Unique identifier for the rhythm pattern variation.",
+      is_default:
+        "If true, this is the baseline Smart Metronome pattern that loads automatically when the user selects this genre/tune-type combination.",
+      name: 'A human-readable description for the UI dropdown (e.g., "Basic Rolling", "Driving Backbeat").',
+      part_target:
+        'Specifies which structural part this pattern targets. "*" or NULL applies to the whole tune, "A" applies only to the A part, "B" to the B part, allowing the groove to change mid-tune.',
+      premium_audio_url:
+        "Optional URL to a pre-recorded audio loop (e.g., an MP3 hosted on Cloudflare R2). If present, the UI logic should prioritize streaming this file over generating the ABC string.",
+      tune_type_id:
+        "Foreign key component referencing the tune type (e.g., JigD).",
     },
   },
   setlist: {
@@ -610,36 +630,37 @@ export function parseOutboxRowId(
 }
 
 export const TABLE_SYNC_ORDER: Record<string, number> = {
-  daily_practice_queue: 5,
-  event: 27,
+  daily_practice_queue: 6,
+  event: 28,
   genre: 1,
   genre_tune_type: 3,
-  goal: 6,
-  group_member: 25,
-  instrument: 7,
-  media_asset: 18,
-  note: 15,
-  plugin: 8,
-  practice_record: 16,
-  prefs_scheduling_options: 9,
-  prefs_spaced_repetition: 10,
-  reference: 17,
-  repertoire: 11,
-  repertoire_tune: 19,
-  setlist: 26,
-  setlist_item: 29,
-  tab_group_main_state: 12,
-  table_state: 13,
-  table_transient_data: 20,
-  tag: 21,
-  tune: 14,
-  tune_override: 22,
-  tune_set: 28,
-  tune_set_item: 30,
+  goal: 7,
+  group_member: 26,
+  instrument: 8,
+  media_asset: 19,
+  note: 16,
+  plugin: 9,
+  practice_record: 17,
+  prefs_scheduling_options: 10,
+  prefs_spaced_repetition: 11,
+  reference: 18,
+  repertoire: 12,
+  repertoire_tune: 20,
+  rhythm_patterns: 4,
+  setlist: 27,
+  setlist_item: 30,
+  tab_group_main_state: 13,
+  table_state: 14,
+  table_transient_data: 21,
+  tag: 22,
+  tune: 15,
+  tune_override: 23,
+  tune_set: 29,
+  tune_set_item: 31,
   tune_type: 2,
-  user_genre_selection: 23,
-  user_group: 24,
-  user_profile: 4,
+  user_genre_selection: 24,
+  user_group: 25,
+  user_profile: 5,
 };
 
 export const TABLE_TO_SCHEMA_KEY: Record<string, string> = {
@@ -659,6 +680,7 @@ export const TABLE_TO_SCHEMA_KEY: Record<string, string> = {
   reference: "reference",
   repertoire: "repertoire",
   repertoire_tune: "repertoireTune",
+  rhythm_patterns: "rhythmPatterns",
   setlist: "setlist",
   setlist_item: "setlistItem",
   tab_group_main_state: "tabGroupMainState",

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -15,12 +15,19 @@ import { useAuth } from "@/lib/auth/AuthContext";
 import { createRhythmService } from "@/lib/services/RhythmService";
 import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import "./rhythm-player.css";
 
 export interface RhythmPlayerProps {
   tuneTypeName: string | null;
   structure?: string | null;
   genreName?: string | null;
   class?: string;
+}
+
+interface ActiveBeatTarget {
+  element: SVGElement;
+  previousFill: string;
+  previousStroke: string;
 }
 
 interface StructurePart {
@@ -36,6 +43,7 @@ interface StructureBarProps {
 
 const DEFAULT_BARS_PER_PART = 8;
 const STRUCTURE_TOKEN = /([^\d\s])(\d*)/g;
+const ACTIVE_NOTE_COLOR = "#60a5fa";
 
 function normalizeStructure(structure?: string | null): string | null {
   const trimmed = structure?.trim();
@@ -205,7 +213,7 @@ function convertRhythmAbcForDisplay(abc: string): string {
 
 export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   const { localDb } = useAuth();
-  let activeBeatTargets: SVGElement[] = [];
+  let activeBeatTargets: ActiveBeatTarget[] = [];
   let lastToastError: string | null = null;
 
   const [isPatternLoading, setIsPatternLoading] = createSignal(false);
@@ -269,8 +277,20 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   });
 
   const clearActiveBeatTargets = () => {
-    for (const element of activeBeatTargets) {
-      element.classList.remove("tnt-active-note");
+    for (const target of activeBeatTargets) {
+      target.element.classList.remove("tnt-active-note");
+
+      if (target.previousFill) {
+        target.element.style.setProperty("fill", target.previousFill);
+      } else {
+        target.element.style.removeProperty("fill");
+      }
+
+      if (target.previousStroke) {
+        target.element.style.setProperty("stroke", target.previousStroke);
+      } else {
+        target.element.style.removeProperty("stroke");
+      }
     }
     activeBeatTargets = [];
   };
@@ -372,7 +392,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     const isSameTargetSet =
       nextTargets.length === activeBeatTargets.length &&
       nextTargets.every(
-        (element, index) => element === activeBeatTargets[index]
+        (element, index) => element === activeBeatTargets[index]?.element
       );
 
     if (isSameTargetSet) {
@@ -380,10 +400,20 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     }
 
     clearActiveBeatTargets();
-    for (const element of nextTargets) {
+    activeBeatTargets = nextTargets.map((element) => {
+      const previousFill = element.style.getPropertyValue("fill");
+      const previousStroke = element.style.getPropertyValue("stroke");
+
       element.classList.add("tnt-active-note");
-    }
-    activeBeatTargets = nextTargets;
+      element.style.setProperty("fill", ACTIVE_NOTE_COLOR);
+      element.style.setProperty("stroke", ACTIVE_NOTE_COLOR);
+
+      return {
+        element,
+        previousFill,
+        previousStroke,
+      };
+    });
   });
 
   onCleanup(() => {
@@ -395,221 +425,166 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   });
 
   return (
-    <>
-      <style>{`
-        .rhythm-player-notation .abcjs-notehead,
-        .rhythm-player-notation .abcjs-note,
-        .rhythm-player-notation .abcjs-stem,
-        .rhythm-player-notation .abcjs-rest,
-        .rhythm-player-notation .abcjs-decoration,
-        .rhythm-player-notation .abcjs-dynamic,
-        .rhythm-player-notation .abcjs-annotation,
-        .rhythm-player-notation .abcjs-slur,
-        .rhythm-player-notation .abcjs-tie {
-          transition:
-            fill 100ms ease,
-            transform 100ms ease;
-          transform-box: fill-box;
-          transform-origin: center;
-          fill: rgb(15 23 42);
-          stroke: rgb(15 23 42);
-          opacity: 1;
-        }
-
-        .rhythm-player-notation .tnt-active-note {
-          fill: #60a5fa !important;
-          stroke: #60a5fa !important;
-          filter: drop-shadow(0 0 8px rgb(96 165 250 / 0.5));
-          transform: scale(1.15);
-        }
-
-        .rhythm-player-notation .abcjs-staff,
-        .rhythm-player-notation .abcjs-bar,
-        .rhythm-player-notation .abcjs-ledger,
-        .rhythm-player-notation .abcjs-clef {
-          stroke: rgb(100 116 139);
-        }
-
-        .dark .rhythm-player-notation .abcjs-notehead,
-        .dark .rhythm-player-notation .abcjs-note,
-        .dark .rhythm-player-notation .abcjs-stem,
-        .dark .rhythm-player-notation .abcjs-rest,
-        .dark .rhythm-player-notation .abcjs-decoration,
-        .dark .rhythm-player-notation .abcjs-dynamic,
-        .dark .rhythm-player-notation .abcjs-annotation,
-        .dark .rhythm-player-notation .abcjs-slur,
-        .dark .rhythm-player-notation .abcjs-tie {
-          fill: rgb(226 232 240);
-          stroke: rgb(226 232 240);
-        }
-
-        .rhythm-player-notation svg {
-          min-width: 100%;
-          height: auto;
-        }
-      `}</style>
-
-      <Card class={cn("border-slate-200 dark:border-slate-800", props.class)}>
-        <CardHeader class="space-y-3">
-          <div class="flex items-start justify-between gap-4">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-                Rhythm Practice
-              </p>
-              <CardTitle class="text-xl text-slate-900 dark:text-slate-50">
-                {props.tuneTypeName?.trim() || "Rhythm Player"}
-              </CardTitle>
-            </div>
-
-            <button
-              type="button"
-              onClick={() => {
-                const currentService = service();
-                if (currentService) {
-                  void currentService.togglePlayback();
-                }
-              }}
-              disabled={!service() || !metadata() || isPatternLoading()}
-              class="inline-flex min-w-28 items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
-              data-testid="rhythm-player-play-toggle"
-            >
-              <Show
-                when={!isPatternLoading()}
-                fallback={<LoaderCircle class="h-4 w-4 animate-spin" />}
-              >
-                {isPlaying() ? (
-                  <Pause class="h-4 w-4" />
-                ) : (
-                  <Play class="h-4 w-4" />
-                )}
-              </Show>
-              {isPatternLoading() ? "Loading" : isPlaying() ? "Pause" : "Play"}
-            </button>
-
-            <button
-              type="button"
-              onClick={() => {
-                const currentService = service();
-                if (currentService) {
-                  void currentService.restart();
-                }
-              }}
-              disabled={!service() || !metadata() || isPatternLoading()}
-              class="inline-flex min-w-28 items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-              data-testid="rhythm-player-restart-button"
-            >
-              <RotateCcw class="h-4 w-4" />
-              Restart
-            </button>
+    <Card class={cn("border-slate-200 dark:border-slate-800", props.class)}>
+      <CardHeader class="space-y-3">
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+              Rhythm Practice
+            </p>
+            <CardTitle class="text-xl text-slate-900 dark:text-slate-50">
+              {props.tuneTypeName?.trim() || "Rhythm Player"}
+            </CardTitle>
           </div>
 
-          <Show when={metadata()}>
-            {(currentMetadata) => (
-              <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-                <div class="space-y-1 text-sm text-slate-600 dark:text-slate-300">
-                  <p>
-                    <span class="font-medium text-slate-900 dark:text-slate-100">
-                      Meter:
-                    </span>{" "}
-                    {currentMetadata().rhythmSignature || "Unknown"}
-                  </p>
-                  <p>
-                    <span class="font-medium text-slate-900 dark:text-slate-100">
-                      Bar:
-                    </span>{" "}
-                    {currentBar() || 0}
-                    <Show when={totalBars() > 0}>
-                      <span class="px-1 text-slate-400">/</span>
-                      {totalBars()}
-                    </Show>
-                  </p>
-                  <Show when={currentPulse() > 0}>
-                    <p>
-                      <span class="font-medium text-slate-900 dark:text-slate-100">
-                        Pulse:
-                      </span>{" "}
-                      {currentPulse()}
-                      <span class="px-1 text-slate-400">/</span>
-                      {pulsesPerBar()}
-                    </p>
-                  </Show>
-                  <p class="text-xs text-slate-500 dark:text-slate-400">
-                    {isReady()
-                      ? "Samples loaded and ready."
-                      : "Samples load on first playback."}
-                  </p>
-                </div>
+          <button
+            type="button"
+            onClick={() => {
+              const currentService = service();
+              if (currentService) {
+                void currentService.togglePlayback();
+              }
+            }}
+            disabled={!service() || !metadata() || isPatternLoading()}
+            class="inline-flex min-w-28 items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+            data-testid="rhythm-player-play-toggle"
+          >
+            <Show
+              when={!isPatternLoading()}
+              fallback={<LoaderCircle class="h-4 w-4 animate-spin" />}
+            >
+              {isPlaying() ? (
+                <Pause class="h-4 w-4" />
+              ) : (
+                <Play class="h-4 w-4" />
+              )}
+            </Show>
+            {isPatternLoading() ? "Loading" : isPlaying() ? "Pause" : "Play"}
+          </button>
 
-                <label class="flex flex-col gap-2 text-sm text-slate-600 dark:text-slate-300">
+          <button
+            type="button"
+            onClick={() => {
+              const currentService = service();
+              if (currentService) {
+                void currentService.restart();
+              }
+            }}
+            disabled={!service() || !metadata() || isPatternLoading()}
+            class="inline-flex min-w-28 items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            data-testid="rhythm-player-restart-button"
+          >
+            <RotateCcw class="h-4 w-4" />
+            Restart
+          </button>
+        </div>
+
+        <Show when={metadata()}>
+          {(currentMetadata) => (
+            <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+              <div class="space-y-1 text-sm text-slate-600 dark:text-slate-300">
+                <p>
                   <span class="font-medium text-slate-900 dark:text-slate-100">
-                    Tempo {tempoQpm()} QPM
-                  </span>
-                  <input
-                    type="range"
-                    min="30"
-                    max="240"
-                    step="1"
-                    value={tempoQpm()}
-                    onInput={(event) => {
-                      const currentService = service();
-                      if (currentService) {
-                        void currentService.setTempoQpm(
-                          Number.parseInt(event.currentTarget.value, 10)
-                        );
-                      }
-                    }}
-                    class="w-full accent-blue-600 md:w-56"
-                    data-testid="rhythm-player-tempo-slider"
-                  />
-                </label>
+                    Meter:
+                  </span>{" "}
+                  {currentMetadata().rhythmSignature || "Unknown"}
+                </p>
+                <p>
+                  <span class="font-medium text-slate-900 dark:text-slate-100">
+                    Bar:
+                  </span>{" "}
+                  {currentBar() || 0}
+                  <Show when={totalBars() > 0}>
+                    <span class="px-1 text-slate-400">/</span>
+                    {totalBars()}
+                  </Show>
+                </p>
+                <Show when={currentPulse() > 0}>
+                  <p>
+                    <span class="font-medium text-slate-900 dark:text-slate-100">
+                      Pulse:
+                    </span>{" "}
+                    {currentPulse()}
+                    <span class="px-1 text-slate-400">/</span>
+                    {pulsesPerBar()}
+                  </p>
+                </Show>
+                <p class="text-xs text-slate-500 dark:text-slate-400">
+                  {isReady()
+                    ? "Samples loaded and ready."
+                    : "Samples load on first playback."}
+                </p>
               </div>
-            )}
-          </Show>
-        </CardHeader>
 
-        <CardContent class="space-y-4">
+              <label class="flex flex-col gap-2 text-sm text-slate-600 dark:text-slate-300">
+                <span class="font-medium text-slate-900 dark:text-slate-100">
+                  Tempo {tempoQpm()} QPM
+                </span>
+                <input
+                  type="range"
+                  min="30"
+                  max="240"
+                  step="1"
+                  value={tempoQpm()}
+                  onInput={(event) => {
+                    const currentService = service();
+                    if (currentService) {
+                      void currentService.setTempoQpm(
+                        Number.parseInt(event.currentTarget.value, 10)
+                      );
+                    }
+                  }}
+                  class="w-full accent-blue-600 md:w-56"
+                  data-testid="rhythm-player-tempo-slider"
+                />
+              </label>
+            </div>
+          )}
+        </Show>
+      </CardHeader>
+
+      <CardContent class="space-y-4">
+        <Show
+          when={localDb()}
+          fallback={
+            <p class="text-sm text-slate-500 dark:text-slate-400">
+              Local database is still loading.
+            </p>
+          }
+        >
           <Show
-            when={localDb()}
+            when={props.tuneTypeName?.trim()}
             fallback={
               <p class="text-sm text-slate-500 dark:text-slate-400">
-                Local database is still loading.
+                Select a tune type to load a rhythm pattern.
               </p>
             }
           >
-            <Show
-              when={props.tuneTypeName?.trim()}
-              fallback={
-                <p class="text-sm text-slate-500 dark:text-slate-400">
-                  Select a tune type to load a rhythm pattern.
-                </p>
-              }
-            >
-              <div class="space-y-4">
-                <StructureBar
-                  structure={effectiveStructure()}
-                  currentMeasure={currentMeasure()}
-                  class="mb-2"
-                />
+            <div class="space-y-4">
+              <StructureBar
+                structure={effectiveStructure()}
+                currentMeasure={currentMeasure()}
+                class="mb-2"
+              />
 
-                <Show when={error() || notationError()}>
-                  <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
-                    {error() || notationError()}
-                  </div>
-                </Show>
-
-                <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/40">
-                  <div
-                    ref={setSvgContainerRef}
-                    class="rhythm-player-notation flex w-full items-center justify-center overflow-x-auto"
-                    data-testid="rhythm-player-notation"
-                  />
+              <Show when={error() || notationError()}>
+                <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
+                  {error() || notationError()}
                 </div>
+              </Show>
+
+              <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/40">
+                <div
+                  ref={setSvgContainerRef}
+                  class="rhythm-player-notation flex w-full items-center justify-center overflow-x-auto"
+                  data-testid="rhythm-player-notation"
+                />
               </div>
-            </Show>
+            </div>
           </Show>
-        </CardContent>
-      </Card>
-    </>
+        </Show>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -1,0 +1,616 @@
+import abcjs from "abcjs";
+import { LoaderCircle, Pause, Play, RotateCcw } from "lucide-solid";
+import {
+  type Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  type JSX,
+  onCleanup,
+  Show,
+} from "solid-js";
+import { toast } from "solid-sonner";
+import { useAuth } from "@/lib/auth/AuthContext";
+import { createRhythmService } from "@/lib/services/RhythmService";
+import { cn } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+
+export interface RhythmPlayerProps {
+  tuneTypeName: string | null;
+  structure?: string | null;
+  genreName?: string | null;
+  class?: string;
+}
+
+interface StructurePart {
+  label: string;
+  bars: number;
+}
+
+interface StructureBarProps {
+  structure?: string | null;
+  currentMeasure: number;
+  class?: string;
+}
+
+const DEFAULT_BARS_PER_PART = 8;
+const STRUCTURE_TOKEN = /([^\d\s])(\d*)/g;
+
+function normalizeStructure(structure?: string | null): string | null {
+  const trimmed = structure?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseStructure(structure?: string | null): StructurePart[] {
+  if (!structure) {
+    return [{ label: "Loop", bars: DEFAULT_BARS_PER_PART }];
+  }
+
+  const parts: StructurePart[] = [];
+  for (const match of structure.matchAll(STRUCTURE_TOKEN)) {
+    const [, rawLabel, rawBars] = match;
+    const bars = Number.parseInt(rawBars, 10);
+    parts.push({
+      label: rawLabel.toUpperCase(),
+      bars: Number.isFinite(bars) ? bars : DEFAULT_BARS_PER_PART,
+    });
+  }
+
+  return parts.length > 0
+    ? parts
+    : [{ label: "Loop", bars: DEFAULT_BARS_PER_PART }];
+}
+
+function getActivePartIndex(
+  parts: StructurePart[],
+  currentMeasure: number
+): number {
+  if (parts.length === 0 || currentMeasure < 1) {
+    return -1;
+  }
+
+  const totalBars = parts.reduce((sum, part) => sum + part.bars, 0);
+  if (totalBars < 1) {
+    return -1;
+  }
+
+  const normalizedMeasure = ((currentMeasure - 1) % totalBars) + 1;
+  let completedBars = 0;
+
+  for (const [index, part] of parts.entries()) {
+    completedBars += part.bars;
+    if (normalizedMeasure <= completedBars) {
+      return index;
+    }
+  }
+
+  return parts.length - 1;
+}
+
+function getBlockClass(isActive: boolean): string {
+  return isActive
+    ? "border-blue-500 bg-blue-600 text-white shadow-sm"
+    : "border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-200";
+}
+
+function StructureBar(props: StructureBarProps): JSX.Element {
+  const parts = createMemo(() => parseStructure(props.structure));
+  const activePartIndex = createMemo(() =>
+    getActivePartIndex(parts(), props.currentMeasure)
+  );
+
+  return (
+    <div class={props.class} data-testid="structure-bar">
+      <ul class="flex flex-wrap gap-2" aria-label="Tune structure">
+        <For each={parts()}>
+          {(part, index) => {
+            const isActive = () => index() === activePartIndex();
+
+            return (
+              <li
+                class={`min-w-20 rounded-xl border px-3 py-2 transition-colors ${getBlockClass(isActive())}`}
+                aria-current={isActive() ? "step" : undefined}
+                aria-label={`${part.label} section, ${part.bars} ${
+                  part.bars === 1 ? "bar" : "bars"
+                }`}
+                data-testid={`structure-bar-part-${index()}`}
+              >
+                <div class="text-sm font-semibold tracking-[0.16em] uppercase">
+                  {part.label}
+                </div>
+                <div class="text-xs opacity-80">
+                  {part.bars} {part.bars === 1 ? "bar" : "bars"}
+                </div>
+              </li>
+            );
+          }}
+        </For>
+      </ul>
+    </div>
+  );
+}
+
+function parseStructureTotalBars(structure?: string | null): number {
+  return parseStructure(structure).reduce(
+    (sum: number, part: { bars: number }) => sum + part.bars,
+    0
+  );
+}
+
+function beatsPerMeasureFromSignature(rhythmSignature?: string | null): number {
+  const numerator = Number.parseInt(rhythmSignature?.split("/")[0] ?? "", 10);
+  return Number.isFinite(numerator) && numerator > 0 ? numerator : 4;
+}
+
+function expandRhythmAbc(
+  abc: string,
+  _structuredBarCount: number,
+  _defaultBarsPerPattern = 4,
+  _structure?: string | null
+): string {
+  return abc;
+}
+
+function getBeatNoteTargets(container: HTMLDivElement): SVGElement[] {
+  return Array.from(container.querySelectorAll<SVGElement>(".abcjs-notehead"));
+}
+
+function collectHighlightTargets(notehead: SVGElement): SVGElement[] {
+  const targets: SVGElement[] = [notehead];
+  const noteGroup = notehead.closest(".abcjs-note");
+
+  if (noteGroup instanceof SVGElement && noteGroup !== notehead) {
+    targets.push(noteGroup);
+  }
+
+  return targets;
+}
+
+/**
+ * Strip the Title (T:) and Tempo (Q:) headers from an ABC string so the
+ * rendered staff shows only clean percussion notation. The TuneTrees UI
+ * already displays this metadata above the SVG.
+ */
+function stripAbcHeaders(abc: string): string {
+  return abc
+    .split("\n")
+    .filter((line) => !line.startsWith("T:") && !line.startsWith("Q:"))
+    .join("\n");
+}
+
+function convertRhythmAbcForDisplay(abc: string): string {
+  return abc
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("K:")) {
+        return "K:C clef=treble";
+      }
+
+      if (/^[A-Za-z]:/.test(line.trim())) {
+        return line;
+      }
+
+      return line.replace(
+        /(?:\^|_|=)?([A-Ga-g])([',]*)/g,
+        (_match, note, octave) => {
+          const normalizedNote = String(note).toLowerCase();
+          const displayNote = normalizedNote === "c" ? "B" : "G";
+          return `${displayNote}${String(octave)}`;
+        }
+      );
+    })
+    .join("\n");
+}
+
+export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
+  const { localDb } = useAuth();
+  let activeBeatTargets: SVGElement[] = [];
+  let lastToastError: string | null = null;
+
+  const [isPatternLoading, setIsPatternLoading] = createSignal(false);
+  const [notationError, setNotationError] = createSignal<string | null>(null);
+  const [svgContainerRef, setSvgContainerRef] = createSignal<HTMLDivElement>();
+
+  const service = createMemo(() => {
+    const db = localDb();
+    return db ? createRhythmService({ db }) : null;
+  });
+
+  const metadata = createMemo(() => service()?.metadata() ?? null);
+  const tempoQpm = createMemo(() => service()?.tempoQpm() ?? 100);
+  const isPlaying = createMemo(() => service()?.isPlaying() ?? false);
+  const isReady = createMemo(() => service()?.isReady() ?? false);
+  const currentBeatIndex = createMemo(() => service()?.currentBeatIndex() ?? 0);
+  const currentMeasure = createMemo(() => service()?.currentMeasure() ?? 0);
+  const error = createMemo(() => service()?.error() ?? null);
+  const effectiveStructure = createMemo(
+    () =>
+      normalizeStructure(props.structure) ?? metadata()?.tuneStructure ?? null
+  );
+  const totalBars = createMemo(() =>
+    parseStructureTotalBars(effectiveStructure())
+  );
+  const pulsesPerBar = createMemo(() =>
+    beatsPerMeasureFromSignature(metadata()?.rhythmSignature ?? null)
+  );
+
+  /**
+   * Expand the rhythm ABC to fill every measure of the tune structure so the
+   * rendered staff shows the full multi-section pattern, not just a 1-2 bar loop.
+   */
+  const expandedAbc = createMemo(() => {
+    const abc = metadata()?.rhythmAbc;
+    const structure = effectiveStructure();
+    if (!abc) return null;
+
+    const structuredBarCount = parseStructureTotalBars(structure);
+    if (structuredBarCount <= 0) return abc;
+
+    return expandRhythmAbc(abc, structuredBarCount, 4, structure);
+  });
+
+  const displayAbc = createMemo(() => {
+    const abc = expandedAbc();
+    if (!abc) return null;
+
+    return stripAbcHeaders(convertRhythmAbcForDisplay(abc));
+  });
+
+  const currentBar = createMemo(() => currentMeasure() || 0);
+  const currentPulse = createMemo(() => {
+    const beatIndex = currentBeatIndex();
+    const beatCountPerBar = pulsesPerBar();
+    if (beatIndex <= 0 || beatCountPerBar <= 0) {
+      return 0;
+    }
+
+    return ((beatIndex - 1) % beatCountPerBar) + 1;
+  });
+
+  const clearActiveBeatTargets = () => {
+    for (const element of activeBeatTargets) {
+      element.classList.remove("tnt-active-note");
+    }
+    activeBeatTargets = [];
+  };
+
+  createEffect(() => {
+    const nextError = error() || notationError();
+    if (!nextError) {
+      lastToastError = null;
+      return;
+    }
+
+    if (nextError === lastToastError) {
+      return;
+    }
+
+    lastToastError = nextError;
+    toast.error(nextError, {
+      id: "rhythm-player-error",
+    });
+  });
+
+  createEffect(() => {
+    const currentService = service();
+    const tuneTypeName = props.tuneTypeName?.trim();
+
+    if (!currentService || !tuneTypeName) {
+      setIsPatternLoading(false);
+      return;
+    }
+
+    setIsPatternLoading(true);
+    void currentService
+      .loadPattern({
+        genreName: props.genreName?.trim() || null,
+        tuneTypeName,
+      })
+      .finally(() => {
+        setIsPatternLoading(false);
+      });
+  });
+
+  // Push expanded ABC to the service so playback matches the rendered measures
+  createEffect(() => {
+    const svc = service();
+    const abc = expandedAbc();
+    if (svc && abc) {
+      svc.updateRhythmAbc(abc);
+    }
+  });
+
+  createEffect(() => {
+    const container = svgContainerRef();
+    const rhythmAbc = displayAbc();
+
+    if (!container) {
+      return;
+    }
+
+    clearActiveBeatTargets();
+    container.innerHTML = "";
+
+    if (!rhythmAbc) {
+      setNotationError(null);
+      return;
+    }
+
+    try {
+      setNotationError(null);
+      abcjs.renderAbc(container, rhythmAbc, {
+        add_classes: true,
+        responsive: "resize",
+      });
+    } catch (cause: unknown) {
+      setNotationError(
+        cause instanceof Error
+          ? cause.message
+          : "Failed to render rhythm notation."
+      );
+    }
+  });
+
+  createEffect(() => {
+    const container = svgContainerRef();
+    const beatIndex = currentBeatIndex();
+    const rhythmAbc = displayAbc();
+
+    if (!container || !rhythmAbc) {
+      return;
+    }
+
+    const noteheads = getBeatNoteTargets(container);
+    if (noteheads.length === 0 || beatIndex < 1) {
+      clearActiveBeatTargets();
+      return;
+    }
+
+    const targetIndex = (beatIndex - 1) % noteheads.length;
+    const nextTargets = collectHighlightTargets(noteheads[targetIndex]!);
+    const isSameTargetSet =
+      nextTargets.length === activeBeatTargets.length &&
+      nextTargets.every(
+        (element, index) => element === activeBeatTargets[index]
+      );
+
+    if (isSameTargetSet) {
+      return;
+    }
+
+    clearActiveBeatTargets();
+    for (const element of nextTargets) {
+      element.classList.add("tnt-active-note");
+    }
+    activeBeatTargets = nextTargets;
+  });
+
+  onCleanup(() => {
+    clearActiveBeatTargets();
+    const container = svgContainerRef();
+    if (container) {
+      container.innerHTML = "";
+    }
+  });
+
+  return (
+    <>
+      <style>{`
+        .rhythm-player-notation .abcjs-notehead,
+        .rhythm-player-notation .abcjs-note,
+        .rhythm-player-notation .abcjs-stem,
+        .rhythm-player-notation .abcjs-rest,
+        .rhythm-player-notation .abcjs-decoration,
+        .rhythm-player-notation .abcjs-dynamic,
+        .rhythm-player-notation .abcjs-annotation,
+        .rhythm-player-notation .abcjs-slur,
+        .rhythm-player-notation .abcjs-tie {
+          transition:
+            fill 100ms ease,
+            transform 100ms ease;
+          transform-box: fill-box;
+          transform-origin: center;
+          fill: rgb(15 23 42);
+          stroke: rgb(15 23 42);
+          opacity: 1;
+        }
+
+        .rhythm-player-notation .tnt-active-note {
+          fill: #60a5fa !important;
+          stroke: #60a5fa !important;
+          filter: drop-shadow(0 0 8px rgb(96 165 250 / 0.5));
+          transform: scale(1.15);
+        }
+
+        .rhythm-player-notation .abcjs-staff,
+        .rhythm-player-notation .abcjs-bar,
+        .rhythm-player-notation .abcjs-ledger,
+        .rhythm-player-notation .abcjs-clef {
+          stroke: rgb(100 116 139);
+        }
+
+        .dark .rhythm-player-notation .abcjs-notehead,
+        .dark .rhythm-player-notation .abcjs-note,
+        .dark .rhythm-player-notation .abcjs-stem,
+        .dark .rhythm-player-notation .abcjs-rest,
+        .dark .rhythm-player-notation .abcjs-decoration,
+        .dark .rhythm-player-notation .abcjs-dynamic,
+        .dark .rhythm-player-notation .abcjs-annotation,
+        .dark .rhythm-player-notation .abcjs-slur,
+        .dark .rhythm-player-notation .abcjs-tie {
+          fill: rgb(226 232 240);
+          stroke: rgb(226 232 240);
+        }
+
+        .rhythm-player-notation svg {
+          min-width: 100%;
+          height: auto;
+        }
+      `}</style>
+
+      <Card class={cn("border-slate-200 dark:border-slate-800", props.class)}>
+        <CardHeader class="space-y-3">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+                Rhythm Practice
+              </p>
+              <CardTitle class="text-xl text-slate-900 dark:text-slate-50">
+                {props.tuneTypeName?.trim() || "Rhythm Player"}
+              </CardTitle>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                const currentService = service();
+                if (currentService) {
+                  void currentService.togglePlayback();
+                }
+              }}
+              disabled={!service() || !metadata() || isPatternLoading()}
+              class="inline-flex min-w-28 items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+              data-testid="rhythm-player-play-toggle"
+            >
+              <Show
+                when={!isPatternLoading()}
+                fallback={<LoaderCircle class="h-4 w-4 animate-spin" />}
+              >
+                {isPlaying() ? (
+                  <Pause class="h-4 w-4" />
+                ) : (
+                  <Play class="h-4 w-4" />
+                )}
+              </Show>
+              {isPatternLoading() ? "Loading" : isPlaying() ? "Pause" : "Play"}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                const currentService = service();
+                if (currentService) {
+                  void currentService.restart();
+                }
+              }}
+              disabled={!service() || !metadata() || isPatternLoading()}
+              class="inline-flex min-w-28 items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              data-testid="rhythm-player-restart-button"
+            >
+              <RotateCcw class="h-4 w-4" />
+              Restart
+            </button>
+          </div>
+
+          <Show when={metadata()}>
+            {(currentMetadata) => (
+              <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+                <div class="space-y-1 text-sm text-slate-600 dark:text-slate-300">
+                  <p>
+                    <span class="font-medium text-slate-900 dark:text-slate-100">
+                      Meter:
+                    </span>{" "}
+                    {currentMetadata().rhythmSignature || "Unknown"}
+                  </p>
+                  <p>
+                    <span class="font-medium text-slate-900 dark:text-slate-100">
+                      Bar:
+                    </span>{" "}
+                    {currentBar() || 0}
+                    <Show when={totalBars() > 0}>
+                      <span class="px-1 text-slate-400">/</span>
+                      {totalBars()}
+                    </Show>
+                  </p>
+                  <Show when={currentPulse() > 0}>
+                    <p>
+                      <span class="font-medium text-slate-900 dark:text-slate-100">
+                        Pulse:
+                      </span>{" "}
+                      {currentPulse()}
+                      <span class="px-1 text-slate-400">/</span>
+                      {pulsesPerBar()}
+                    </p>
+                  </Show>
+                  <p class="text-xs text-slate-500 dark:text-slate-400">
+                    {isReady()
+                      ? "Samples loaded and ready."
+                      : "Samples load on first playback."}
+                  </p>
+                </div>
+
+                <label class="flex flex-col gap-2 text-sm text-slate-600 dark:text-slate-300">
+                  <span class="font-medium text-slate-900 dark:text-slate-100">
+                    Tempo {tempoQpm()} QPM
+                  </span>
+                  <input
+                    type="range"
+                    min="30"
+                    max="240"
+                    step="1"
+                    value={tempoQpm()}
+                    onInput={(event) => {
+                      const currentService = service();
+                      if (currentService) {
+                        void currentService.setTempoQpm(
+                          Number.parseInt(event.currentTarget.value, 10)
+                        );
+                      }
+                    }}
+                    class="w-full accent-blue-600 md:w-56"
+                    data-testid="rhythm-player-tempo-slider"
+                  />
+                </label>
+              </div>
+            )}
+          </Show>
+        </CardHeader>
+
+        <CardContent class="space-y-4">
+          <Show
+            when={localDb()}
+            fallback={
+              <p class="text-sm text-slate-500 dark:text-slate-400">
+                Local database is still loading.
+              </p>
+            }
+          >
+            <Show
+              when={props.tuneTypeName?.trim()}
+              fallback={
+                <p class="text-sm text-slate-500 dark:text-slate-400">
+                  Select a tune type to load a rhythm pattern.
+                </p>
+              }
+            >
+              <div class="space-y-4">
+                <StructureBar
+                  structure={effectiveStructure()}
+                  currentMeasure={currentMeasure()}
+                  class="mb-2"
+                />
+
+                <Show when={error() || notationError()}>
+                  <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
+                    {error() || notationError()}
+                  </div>
+                </Show>
+
+                <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/40">
+                  <div
+                    ref={setSvgContainerRef}
+                    class="rhythm-player-notation flex w-full items-center justify-center overflow-x-auto"
+                    data-testid="rhythm-player-notation"
+                  />
+                </div>
+              </div>
+            </Show>
+          </Show>
+        </CardContent>
+      </Card>
+    </>
+  );
+};
+
+export default RhythmPlayer;

--- a/src/components/rhythm/rhythm-player.css
+++ b/src/components/rhythm/rhythm-player.css
@@ -1,0 +1,48 @@
+.rhythm-player-notation .abcjs-notehead,
+.rhythm-player-notation .abcjs-note,
+.rhythm-player-notation .abcjs-stem,
+.rhythm-player-notation .abcjs-rest,
+.rhythm-player-notation .abcjs-decoration,
+.rhythm-player-notation .abcjs-dynamic,
+.rhythm-player-notation .abcjs-annotation,
+.rhythm-player-notation .abcjs-slur,
+.rhythm-player-notation .abcjs-tie {
+  transition:
+    fill 100ms ease,
+    transform 100ms ease;
+  transform-box: fill-box;
+  transform-origin: center;
+  fill: rgb(15 23 42);
+  stroke: rgb(15 23 42);
+  opacity: 1;
+}
+
+.rhythm-player-notation .tnt-active-note {
+  filter: drop-shadow(0 0 8px rgb(96 165 250 / 0.5));
+  transform: scale(1.15);
+}
+
+.rhythm-player-notation .abcjs-staff,
+.rhythm-player-notation .abcjs-bar,
+.rhythm-player-notation .abcjs-ledger,
+.rhythm-player-notation .abcjs-clef {
+  stroke: rgb(100 116 139);
+}
+
+.dark .rhythm-player-notation .abcjs-notehead,
+.dark .rhythm-player-notation .abcjs-note,
+.dark .rhythm-player-notation .abcjs-stem,
+.dark .rhythm-player-notation .abcjs-rest,
+.dark .rhythm-player-notation .abcjs-decoration,
+.dark .rhythm-player-notation .abcjs-dynamic,
+.dark .rhythm-player-notation .abcjs-annotation,
+.dark .rhythm-player-notation .abcjs-slur,
+.dark .rhythm-player-notation .abcjs-tie {
+  fill: rgb(226 232 240);
+  stroke: rgb(226 232 240);
+}
+
+.rhythm-player-notation svg {
+  min-width: 100%;
+  height: auto;
+}

--- a/src/lib/db/client-sqlite.ts
+++ b/src/lib/db/client-sqlite.ts
@@ -38,8 +38,8 @@ export const browserSqliteClient = createBrowserSqliteClient({
     outboxBackupKeyPrefix: "tunetrees-outbox-backup",
     lastSyncTimestampKeyPrefix: "TT_LAST_SYNC_TIMESTAMP",
   },
-  databaseVersion: 18,
-  schemaVersion: "2.0.9-rename-program-to-setlist",
+  databaseVersion: 19,
+  schemaVersion: "2.0.10-add-rhythm-patterns",
   migrationFiles: [
     "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",
     "/drizzle/migrations/sqlite/0001_thin_chronomancer.sql",
@@ -60,6 +60,7 @@ export const browserSqliteClient = createBrowserSqliteClient({
     "/drizzle/migrations/sqlite/0016_add_programs.sql",
     "/drizzle/migrations/sqlite/0017_fix_ordered_item_conflict_targets.sql",
     "/drizzle/migrations/sqlite/0018_rename_program_to_setlist.sql",
+    "/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql",
   ],
   forceResetQueryParams: [
     { key: "reset", value: "true" },

--- a/src/lib/db/migration-version.ts
+++ b/src/lib/db/migration-version.ts
@@ -8,7 +8,7 @@
  * @module lib/db/migration-version
  */
 
-const CURRENT_SCHEMA_VERSION = "2.0.9-rename-program-to-setlist"; // Bump this when schema changes
+const CURRENT_SCHEMA_VERSION = "2.0.10-add-rhythm-patterns"; // Bump this when schema changes
 
 /**
  * Get the locally stored schema version from localStorage

--- a/src/lib/services/RhythmService.test.ts
+++ b/src/lib/services/RhythmService.test.ts
@@ -24,18 +24,18 @@ function createReferenceRhythmDb() {
   return createDb([
     "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
     "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
-    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, tempo INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
-    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, rhythm_abc TEXT, sample_kit TEXT, tune_structure TEXT)",
+    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT)",
     "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
     "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
-    "INSERT INTO genre_tune_type (genre_id, tune_type_id, tempo) VALUES ('ITRAD', 'Reel', 112)",
-    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, rhythm_abc, sample_kit, tune_structure)
-      VALUES ('rp-1', 'ITRAD', 'Reel', 'X:1
+    "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
+    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url)
+      VALUES ('rp-1', 'ITRAD', 'Reel', 'Basic Rolling', '*', 'X:1
 T:Reel Groove
 M:4/4
 L:1/8
 K:clef=perc
-|: C2 A2 C2 A2 :|', 'bodhran_bosone', 'AABB')`,
+|: C2 A2 C2 A2 :|', 1, NULL)`,
   ]);
 }
 
@@ -46,12 +46,24 @@ function createFallbackRhythmDb() {
   ]);
 }
 
+function createRhythmDbWithoutPatternRow() {
+  return createDb([
+    "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
+    "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
+    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT)",
+    "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
+    "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
+    "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
+  ]);
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("loadRhythmPatternMetadata", () => {
-  it("prefers rhythm_patterns and genre_tune_type.tempo when available", async () => {
+  it("prefers rhythm_patterns and genre_tune_type.default_bpm when available", async () => {
     const db = createReferenceRhythmDb();
 
     const metadata = await loadRhythmPatternMetadata(db, {
@@ -67,6 +79,17 @@ describe("loadRhythmPatternMetadata", () => {
       source: "rhythm_patterns",
     });
     expect(metadata?.rhythmAbc).toContain("Reel Groove");
+  });
+
+  it("does not synthesize fallback ABC when rhythm_patterns exists but has no matching row", async () => {
+    const db = createRhythmDbWithoutPatternRow();
+
+    const metadata = await loadRhythmPatternMetadata(db, {
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+    });
+
+    expect(metadata).toBeNull();
   });
 
   it("falls back to generated percussion ABC and default tempo when new tables are absent", async () => {

--- a/src/lib/services/RhythmService.test.ts
+++ b/src/lib/services/RhythmService.test.ts
@@ -58,6 +58,18 @@ function createRhythmDbWithoutPatternRow() {
   ]);
 }
 
+function createRhythmDbWithLegacyPatternColumns() {
+  return createDb([
+    "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
+    "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
+    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, tune_type_id TEXT NOT NULL, abc_string TEXT NOT NULL)",
+    "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
+    "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
+    "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
+  ]);
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -81,7 +93,7 @@ describe("loadRhythmPatternMetadata", () => {
     expect(metadata?.rhythmAbc).toContain("Reel Groove");
   });
 
-  it("does not synthesize fallback ABC when rhythm_patterns exists but has no matching row", async () => {
+  it("falls back to generated ABC when rhythm_patterns has no matching row", async () => {
     const db = createRhythmDbWithoutPatternRow();
 
     const metadata = await loadRhythmPatternMetadata(db, {
@@ -89,7 +101,32 @@ describe("loadRhythmPatternMetadata", () => {
       tuneTypeName: "Reel",
     });
 
-    expect(metadata).toBeNull();
+    expect(metadata).toMatchObject({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      tempoQpm: 112,
+      sampleKit: "bodhran_bosone",
+      source: "tune_type_fallback",
+    });
+    expect(metadata?.rhythmAbc).toContain("M:4/4");
+  });
+
+  it("falls back when rhythm_patterns exists with an older partial schema", async () => {
+    const db = createRhythmDbWithLegacyPatternColumns();
+
+    const metadata = await loadRhythmPatternMetadata(db, {
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+    });
+
+    expect(metadata).toMatchObject({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      tempoQpm: 112,
+      sampleKit: "bodhran_bosone",
+      source: "tune_type_fallback",
+    });
+    expect(metadata?.rhythmAbc).toContain("M:4/4");
   });
 
   it("falls back to generated percussion ABC and default tempo when new tables are absent", async () => {

--- a/src/lib/services/RhythmService.ts
+++ b/src/lib/services/RhythmService.ts
@@ -33,6 +33,7 @@ export interface RhythmPatternMetadata {
   tuneTypeName: string;
   rhythmAbc: string;
   rhythmSignature: string | null;
+  tuneStructure?: string | null;
   tempoQpm: number;
   sampleKit: string;
   source: "rhythm_patterns" | "tune_type_fallback";
@@ -51,8 +52,10 @@ export interface RhythmService {
   ) => Promise<RhythmPatternMetadata | null>;
   play: () => Promise<void>;
   pause: () => void;
+  restart: () => Promise<void>;
   togglePlayback: () => Promise<void>;
   setTempoQpm: (nextQpm: number) => Promise<void>;
+  updateRhythmAbc: (nextRhythmAbc: string) => void;
 }
 
 export interface CreateRhythmServiceOptions {
@@ -61,6 +64,7 @@ export interface CreateRhythmServiceOptions {
   audioContext?: AudioContext;
   fetchImpl?: typeof fetch;
   sampleBaseUrl?: string;
+  sampleUrlBuilder?: (sampleKit: string, fileName: string) => string;
 }
 
 type ResolvedAbcjsModule = NonNullable<
@@ -160,8 +164,8 @@ export async function loadRhythmPatternMetadata(
     return null;
   }
 
-  const hasGenreTempoColumn = (await tableExists(db, "genre_tune_type"))
-    ? (await getTableColumns(db, "genre_tune_type")).has("tempo")
+  const hasGenreDefaultBpmColumn = (await tableExists(db, "genre_tune_type"))
+    ? (await getTableColumns(db, "genre_tune_type")).has("default_bpm")
     : false;
   const hasRhythmPatternsTable = await tableExists(db, "rhythm_patterns");
 
@@ -171,20 +175,97 @@ export async function loadRhythmPatternMetadata(
 
   const canUseRhythmPatterns =
     hasRhythmPatternsTable &&
-    rhythmPatternColumns.has("rhythm_abc") &&
-    rhythmPatternColumns.has("sample_kit") &&
+    rhythmPatternColumns.has("abc_string") &&
     rhythmPatternColumns.has("tune_type_id");
 
   const genreFilter = request.genreName?.trim() || null;
 
-  if (hasGenreTempoColumn || canUseRhythmPatterns) {
+  if (canUseRhythmPatterns) {
     const rows = await db.all<{
       genre_name: string | null;
       tune_type_name: string | null;
       rhythm_signature: string | null;
       tempo_qpm: number | null;
-      rhythm_abc: string | null;
-      sample_kit: string | null;
+      abc_string: string | null;
+    }>(sql`
+      WITH tune_type_match AS (
+        SELECT id, name, rhythm
+        FROM tune_type
+        WHERE lower(name) = lower(${tuneTypeName})
+        LIMIT 1
+      ),
+      genre_match AS (
+        SELECT id, name
+        FROM genre
+        WHERE ${genreFilter} IS NOT NULL
+          AND lower(name) = lower(${genreFilter})
+        LIMIT 1
+      ),
+      selected_pattern AS (
+        SELECT
+          rp.genre_id,
+          rp.tune_type_id,
+          rp.abc_string,
+          rp.is_default,
+          rp.part_target,
+          ROW_NUMBER() OVER (
+            ORDER BY
+              CASE WHEN rp.is_default THEN 0 ELSE 1 END,
+              CASE
+                WHEN rp.part_target IS NULL OR rp.part_target = '*' THEN 0
+                ELSE 1
+              END,
+              rp.name
+          ) AS row_num
+        FROM rhythm_patterns rp
+        JOIN tune_type_match ttm ON rp.tune_type_id = ttm.id
+        LEFT JOIN genre_match gm ON 1 = 1
+        WHERE (gm.id IS NULL OR rp.genre_id = gm.id)
+      )
+      SELECT
+        gm.name AS genre_name,
+        ttm.name AS tune_type_name,
+        ttm.rhythm AS rhythm_signature,
+        ${
+          hasGenreDefaultBpmColumn
+            ? sql`gtt.default_bpm`
+            : sql`CAST(NULL AS INTEGER)`
+        } AS tempo_qpm,
+        sp.abc_string AS abc_string
+      FROM tune_type_match ttm
+      LEFT JOIN genre_match gm ON 1 = 1
+      LEFT JOIN genre_tune_type gtt
+        ON gtt.tune_type_id = ttm.id
+       AND (gm.id IS NULL OR gtt.genre_id = gm.id)
+      LEFT JOIN selected_pattern sp ON sp.row_num = 1
+      LIMIT 1
+    `);
+
+    const row = rows[0];
+    if (row?.tune_type_name && row.abc_string?.trim()) {
+      return {
+        genreName: row.genre_name ?? genreFilter,
+        tuneTypeName: row.tune_type_name,
+        rhythmSignature: row.rhythm_signature ?? null,
+        rhythmAbc: row.abc_string.trim(),
+        tempoQpm:
+          typeof row.tempo_qpm === "number" && Number.isFinite(row.tempo_qpm)
+            ? row.tempo_qpm
+            : getDefaultTempoForTuneType(row.tune_type_name),
+        sampleKit: DEFAULT_SAMPLE_KIT,
+        source: "rhythm_patterns",
+      };
+    }
+
+    return null;
+  }
+
+  if (hasGenreDefaultBpmColumn) {
+    const rows = await db.all<{
+      genre_name: string | null;
+      tune_type_name: string | null;
+      rhythm_signature: string | null;
+      tempo_qpm: number | null;
     }>(sql`
       WITH tune_type_match AS (
         SELECT id, name, rhythm
@@ -203,48 +284,31 @@ export async function loadRhythmPatternMetadata(
         gm.name AS genre_name,
         ttm.name AS tune_type_name,
         ttm.rhythm AS rhythm_signature,
-        ${
-          hasGenreTempoColumn ? sql`gtt.tempo` : sql`CAST(NULL AS INTEGER)`
-        } AS tempo_qpm,
-        ${
-          canUseRhythmPatterns ? sql`rp.rhythm_abc` : sql`CAST(NULL AS TEXT)`
-        } AS rhythm_abc,
-        ${
-          canUseRhythmPatterns ? sql`rp.sample_kit` : sql`CAST(NULL AS TEXT)`
-        } AS sample_kit
+        gtt.default_bpm AS tempo_qpm
       FROM tune_type_match ttm
       LEFT JOIN genre_match gm ON 1 = 1
       LEFT JOIN genre_tune_type gtt
         ON gtt.tune_type_id = ttm.id
        AND (gm.id IS NULL OR gtt.genre_id = gm.id)
-      ${
-        canUseRhythmPatterns
-          ? sql`LEFT JOIN rhythm_patterns rp
-              ON rp.tune_type_id = ttm.id
-             AND (gm.id IS NULL OR rp.genre_id = gm.id)`
-          : sql``
-      }
       LIMIT 1
     `);
 
     const row = rows[0];
     if (row?.tune_type_name) {
-      const rhythmSignature = row.rhythm_signature ?? null;
       return {
         genreName: row.genre_name ?? genreFilter,
         tuneTypeName: row.tune_type_name,
-        rhythmSignature,
-        rhythmAbc:
-          row.rhythm_abc?.trim() ||
-          buildFallbackRhythmAbc(row.tune_type_name, rhythmSignature),
+        rhythmSignature: row.rhythm_signature ?? null,
+        rhythmAbc: buildFallbackRhythmAbc(
+          row.tune_type_name,
+          row.rhythm_signature ?? null
+        ),
         tempoQpm:
           typeof row.tempo_qpm === "number" && Number.isFinite(row.tempo_qpm)
             ? row.tempo_qpm
             : getDefaultTempoForTuneType(row.tune_type_name),
-        sampleKit: row.sample_kit?.trim() || DEFAULT_SAMPLE_KIT,
-        source: row.rhythm_abc?.trim()
-          ? "rhythm_patterns"
-          : "tune_type_fallback",
+        sampleKit: DEFAULT_SAMPLE_KIT,
+        source: "tune_type_fallback",
       };
     }
   }
@@ -383,7 +447,9 @@ export function createRhythmService(
         const buffer = await decodeSample(
           audioContext,
           fetchImpl,
-          `${sampleBaseUrl}/${fileName}`
+          options.sampleUrlBuilder
+            ? options.sampleUrlBuilder(DEFAULT_SAMPLE_KIT, fileName)
+            : `${sampleBaseUrl}/${fileName}`
         );
         return [Number(pitch), buffer] as const;
       })
@@ -525,6 +591,38 @@ export function createRhythmService(
     await play();
   }
 
+  async function restart(): Promise<void> {
+    lastKnownPositionMs = 0;
+    setCurrentBeatIndex(0);
+    setCurrentMeasure(0);
+
+    if (!metadata()) {
+      return;
+    }
+
+    if (isPlaying()) {
+      await startPlayback(0);
+    }
+  }
+
+  function updateRhythmAbc(nextRhythmAbc: string): void {
+    const currentMetadata = metadata();
+    const trimmedRhythmAbc = nextRhythmAbc.trim();
+
+    if (!currentMetadata || !trimmedRhythmAbc) {
+      return;
+    }
+
+    if (currentMetadata.rhythmAbc === trimmedRhythmAbc) {
+      return;
+    }
+
+    setMetadata({
+      ...currentMetadata,
+      rhythmAbc: trimmedRhythmAbc,
+    });
+  }
+
   async function setTempoQpm(nextQpm: number) {
     const clamped = clampTempo(nextQpm);
     setTempoQpmSignal(clamped);
@@ -586,6 +684,16 @@ export function createRhythmService(
       }
     },
     pause,
+    restart: async () => {
+      try {
+        await restart();
+      } catch (cause: unknown) {
+        const message =
+          cause instanceof Error ? cause.message : "Failed to restart rhythm.";
+        setError(message);
+        stopPlayback();
+      }
+    },
     togglePlayback: async () => {
       try {
         await togglePlayback();
@@ -599,5 +707,6 @@ export function createRhythmService(
       }
     },
     setTempoQpm,
+    updateRhythmAbc,
   };
 }

--- a/src/lib/services/RhythmService.ts
+++ b/src/lib/services/RhythmService.ts
@@ -10,6 +10,14 @@ import type { SqliteDatabase } from "@/lib/db/client-sqlite";
 
 const DEFAULT_SAMPLE_BASE_URL = "/samples/bodhran";
 const DEFAULT_SAMPLE_KIT = "bodhran_bosone";
+const REQUIRED_RHYTHM_PATTERN_COLUMNS = [
+  "abc_string",
+  "genre_id",
+  "is_default",
+  "name",
+  "part_target",
+  "tune_type_id",
+] as const;
 const SAMPLE_FILE_BY_PITCH: Record<number, string> = {
   60: "bass.mp3",
   69: "rim.mp3",
@@ -175,8 +183,9 @@ export async function loadRhythmPatternMetadata(
 
   const canUseRhythmPatterns =
     hasRhythmPatternsTable &&
-    rhythmPatternColumns.has("abc_string") &&
-    rhythmPatternColumns.has("tune_type_id");
+    REQUIRED_RHYTHM_PATTERN_COLUMNS.every((column) =>
+      rhythmPatternColumns.has(column)
+    );
 
   const genreFilter = request.genreName?.trim() || null;
 
@@ -256,8 +265,6 @@ export async function loadRhythmPatternMetadata(
         source: "rhythm_patterns",
       };
     }
-
-    return null;
   }
 
   if (hasGenreDefaultBpmColumn) {

--- a/supabase/migrations/20260511000000_add_rhythm_patterns_and_default_bpm.sql
+++ b/supabase/migrations/20260511000000_add_rhythm_patterns_and_default_bpm.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+-- ============================================================================
+-- Migration: Add rhythm pattern storage and default BPM metadata
+-- Issue: #607 - Rhythm Engine UI & Schema Expansion (Phase 2)
+-- ============================================================================
+
+ALTER TABLE public.genre_tune_type
+ADD COLUMN default_bpm INTEGER;
+
+COMMENT ON COLUMN public.genre_tune_type.default_bpm IS 'The baseline tempo (Beats/Quarter-notes Per Minute) for this specific genre and tune type combination (e.g., 115 for an ITRAD JigD).';
+
+CREATE TABLE public.rhythm_patterns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  genre_id TEXT NOT NULL,
+  tune_type_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  part_target TEXT DEFAULT '*',
+  abc_string TEXT NOT NULL,
+  is_default BOOLEAN NOT NULL DEFAULT false,
+  premium_audio_url TEXT,
+
+  CONSTRAINT rhythm_patterns_genre_id_fkey
+    FOREIGN KEY (genre_id)
+    REFERENCES public.genre (id)
+    ON DELETE CASCADE,
+  CONSTRAINT rhythm_patterns_tune_type_id_fkey
+    FOREIGN KEY (tune_type_id)
+    REFERENCES public.tune_type (id)
+    ON DELETE CASCADE
+) TABLESPACE pg_default;
+
+ALTER TABLE public.rhythm_patterns ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can view rhythm_patterns"
+ON public.rhythm_patterns
+FOR SELECT
+USING (true);
+
+COMMENT ON TABLE public.rhythm_patterns IS 'Stores the ABC percussion strings and optional premium audio loop URLs for generating rhythm accompaniment, allowing for per-part variations and overrides.';
+
+COMMENT ON COLUMN public.rhythm_patterns.id IS 'Unique identifier for the rhythm pattern variation.';
+
+COMMENT ON COLUMN public.rhythm_patterns.genre_id IS 'Foreign key component referencing the genre (e.g., ITRAD).';
+
+COMMENT ON COLUMN public.rhythm_patterns.tune_type_id IS 'Foreign key component referencing the tune type (e.g., JigD).';
+
+COMMENT ON COLUMN public.rhythm_patterns.name IS 'A human-readable description for the UI dropdown (e.g., "Basic Rolling", "Driving Backbeat").';
+
+COMMENT ON COLUMN public.rhythm_patterns.part_target IS 'Specifies which structural part this pattern targets. "*" or NULL applies to the whole tune, "A" applies only to the A part, "B" to the B part, allowing the groove to change mid-tune.';
+
+COMMENT ON COLUMN public.rhythm_patterns.abc_string IS 'The 2-bar or 4-bar ABC notation string used by the abcjs TimingCallbacks engine to generate the metronome loop (e.g., |: C2 c C c c :|).';
+
+COMMENT ON COLUMN public.rhythm_patterns.is_default IS 'If true, this is the baseline Smart Metronome pattern that loads automatically when the user selects this genre/tune-type combination.';
+
+COMMENT ON COLUMN public.rhythm_patterns.premium_audio_url IS 'Optional URL to a pre-recorded audio loop (e.g., an MP3 hosted on Cloudflare R2). If present, the UI logic should prioritize streaming this file over generating the ABC string.';
+
+COMMIT;

--- a/tests/lib/db/install-triggers.test.ts
+++ b/tests/lib/db/install-triggers.test.ts
@@ -83,6 +83,19 @@ beforeEach(async () => {
   `);
 
   db.run(`
+    CREATE TABLE rhythm_patterns (
+      id TEXT PRIMARY KEY NOT NULL,
+      genre_id TEXT NOT NULL,
+      tune_type_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      part_target TEXT,
+      abc_string TEXT NOT NULL,
+      is_default INTEGER NOT NULL DEFAULT 0,
+      premium_audio_url TEXT
+    )
+  `);
+
+  db.run(`
     CREATE TABLE note (
       id TEXT PRIMARY KEY NOT NULL,
       content TEXT,

--- a/tests/lib/sync/table-meta.test.ts
+++ b/tests/lib/sync/table-meta.test.ts
@@ -39,8 +39,8 @@ describe("TABLE_REGISTRY completeness", () => {
 
   it("has the expected number of tables", () => {
     // Update this if adding/removing tables
-    expect(SYNCABLE_TABLES.length).toBe(30);
-    expect(Object.keys(TABLE_REGISTRY).length).toBe(30);
+    expect(SYNCABLE_TABLES.length).toBe(31);
+    expect(Object.keys(TABLE_REGISTRY).length).toBe(31);
   });
 });
 

--- a/worker/src/generated/schema-postgres.generated.ts
+++ b/worker/src/generated/schema-postgres.generated.ts
@@ -80,6 +80,7 @@ export const genre = pgTable("genre", {
 export const genreTuneType = pgTable("genre_tune_type", {
   genreId: text("genre_id").notNull(),
   tuneTypeId: text("tune_type_id").notNull(),
+  defaultBpm: integer("default_bpm"),
 });
 
 export const goal = pgTable("goal", {
@@ -315,6 +316,20 @@ export const repertoireTune = pgTable("repertoire_tune", {
     .notNull()
     .$defaultFn(() => new Date().toISOString()),
   deviceId: text("device_id"),
+});
+
+export const rhythmPatterns = pgTable("rhythm_patterns", {
+  id: uuid("id")
+    .notNull()
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  genreId: text("genre_id").notNull(),
+  tuneTypeId: text("tune_type_id").notNull(),
+  name: text("name").notNull(),
+  partTarget: text("part_target").default("*"),
+  abcString: text("abc_string").notNull(),
+  isDefault: boolean("is_default").notNull().default(false),
+  premiumAudioUrl: text("premium_audio_url"),
 });
 
 export const setlist = pgTable("setlist", {
@@ -601,6 +616,7 @@ export const tables = {
   reference: reference,
   repertoire: repertoire,
   repertoire_tune: repertoireTune,
+  rhythm_patterns: rhythmPatterns,
   setlist: setlist,
   setlist_item: setlistItem,
   sync_change_log: syncChangeLog,

--- a/worker/src/generated/worker-config.generated.ts
+++ b/worker/src/generated/worker-config.generated.ts
@@ -460,6 +460,14 @@ export const WORKER_SYNC_CONFIG = {
       },
       genre_tune_type: {
         denyDelete: true,
+        sanitize: {
+          coerceNumericProps: [
+            {
+              prop: "defaultBpm",
+              kind: "int",
+            },
+          ],
+        },
       },
       goal: {
         sanitize: {
@@ -695,6 +703,9 @@ export const WORKER_SYNC_CONFIG = {
             },
           ],
         },
+      },
+      rhythm_patterns: {
+        denyDelete: true,
       },
       setlist: {
         sanitize: {


### PR DESCRIPTION
## Summary

This PR delivers a mergeable slice of the rhythm accompaniment work for [#607](https://github.com/sboagy/tunetrees/issues/607).

It adds the new rhythm-pattern schema and local migration/bootstrap support, updates `RhythmService` to consume stored pattern data, introduces the initial `RhythmPlayer` UI, and fixes the unit/E2E regressions caused by the schema expansion.

This PR is intended to be one incremental step toward #607 and does **not** close that issue.

## Included in this PR

- add `genre_tune_type.default_bpm`
- add `rhythm_patterns` in Supabase and SQLite migrations
- regenerate sync/schema/worker artifacts for the new table
- bump local SQLite schema versioning so browser bootstrap stays aligned
- update `RhythmService` to load authoritative ABC/default BPM data from the DB
- add the initial `RhythmPlayer` implementation, including structure display and ABCJS rendering
- fix affected unit tests and browser bootstrap issues
- stabilize the remaining local E2E failure in the repeated-Easy scheduling test
- make Playwright auth bootstrap resilient after full local Supabase resets

## Not included in this PR

- full completion of [#607](https://github.com/sboagy/tunetrees/issues/607)
- population of initial Batch 1 rhythm pattern seed data
- premium audio upload/integration
- any remaining UI wiring beyond this initial player slice

## Validation

- `npm run lint && npm run check && npm run typecheck && npm run test:unit`
- `npx playwright test scheduling-003-repeated-easy.spec.ts --project=chromium`
