### PR TITLE
Add rhythm sample-kit registry and R2 loop support

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -68,6 +68,11 @@ GITHUB_REPO=tunetrees
 # This is likely configured to be unique from other rhizome apps to avoid conflicts
 VITE_WORKER_URL="op://rhizome/shared-local/Vite/VITE_WORKER_URL_TUNETREES"
 
+# Public base URL for rhythm audio assets stored in Cloudflare R2.
+# Example: https://media.example.com
+# If unset, the app resolves kit samples from /audio/kits/... on the same origin.
+VITE_R2_AUDIO_BASE_URL="https://pub-c77b0e0025a0474588b12433d1a025db.r2.dev"
+
 # Enable debug logging for sync operations (default: false)
 # Set to 'true' to see detailed sync logs in console
 # VITE_SYNC_DEBUG=true

--- a/.env.prod.template
+++ b/.env.prod.template
@@ -62,6 +62,11 @@ GITHUB_REPO=tunetrees
 # a local worker URL such as http://localhost:8797.
 VITE_WORKER_URL="op://rhizome/shared-production/Vite/VITE_WORKER_URL_TUNETREES"
 
+# Public base URL for rhythm audio assets stored in Cloudflare R2.
+# Example: https://media.example.com
+# If unset, the app resolves kit samples from /audio/kits/... on the same origin.
+VITE_R2_AUDIO_BASE_URL="https://pub-c77b0e0025a0474588b12433d1a025db.r2.dev"
+
 # Enable debug logging for sync operations (default: false)
 # Set to 'true' to see detailed sync logs in console
 # VITE_SYNC_DEBUG=true

--- a/drizzle/migrations/sqlite/0020_add_sample_kit_to_rhythm_patterns.sql
+++ b/drizzle/migrations/sqlite/0020_add_sample_kit_to_rhythm_patterns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `rhythm_patterns`
+ADD COLUMN `sample_kit` text DEFAULT 'bodhran' NOT NULL;

--- a/drizzle/schema-sqlite.generated.ts
+++ b/drizzle/schema-sqlite.generated.ts
@@ -442,6 +442,7 @@ export const rhythmPatterns = sqliteTable("rhythm_patterns", {
   abcString: text("abc_string").notNull(),
   isDefault: integer("is_default").notNull().default(0),
   premiumAudioUrl: text("premium_audio_url"),
+  sampleKit: text("sample_kit").notNull().default("bodhran"),
 });
 
 export const setlist = sqliteTable(

--- a/e2e/tests/practice-005-date-rollover-banner.spec.ts
+++ b/e2e/tests/practice-005-date-rollover-banner.spec.ts
@@ -64,6 +64,19 @@ async function waitForTestApi(page: Page) {
   });
 }
 
+async function resetLocalDbAndReopenPractice(page: Page, userId: string) {
+  await resetLocalDbAndResync(page);
+  ttPage = new TuneTreesPage(page);
+  await setInjectedTestUserId(page, userId);
+
+  // Some reset flows can leave the browser parked on e2e-origin.html after the
+  // storage clear finishes. Re-open the app explicitly so subsequent Practice
+  // assertions are scoped to the real UI instead of the origin helper page.
+  await page.goto("/?tab=practice", { waitUntil: "domcontentloaded" });
+  await waitForTestApi(page);
+  await expect(ttPage.practiceGrid).toBeVisible({ timeout: 20000 });
+}
+
 async function getQueueRows(page: Page, repertoireId: string) {
   return await page.evaluate(async (rid) => {
     const api = (window as any).__ttTestApi;
@@ -541,12 +554,7 @@ test.describe("PRACTICE-005: Date Rollover Banner", () => {
 
     expect(expectedPendingOrder.length).toBeGreaterThan(0);
 
-    await resetLocalDbAndResync(page);
-    ttPage = new TuneTreesPage(page);
-    await setInjectedTestUserId(page, testUser.userId);
-    await waitForTestApi(page);
-
-    await ttPage.navigateToTab("practice");
+    await resetLocalDbAndReopenPractice(page, testUser.userId);
 
     const queueAfterReset = await getQueueSnapshot(page, testUser.repertoireId);
     const pendingAfterReset = getPendingTuneOrder(queueAfterReset.rows);
@@ -590,12 +598,7 @@ test.describe("PRACTICE-005: Date Rollover Banner", () => {
     currentDate = await advanceDays(context, 1, currentDate);
     await expect(ttPage.dateRolloverBanner).toBeVisible({ timeout: 10000 });
 
-    await resetLocalDbAndResync(page);
-    ttPage = new TuneTreesPage(page);
-    await setInjectedTestUserId(page, testUser.userId);
-    await waitForTestApi(page);
-
-    await ttPage.navigateToTab("practice");
+    await resetLocalDbAndReopenPractice(page, testUser.userId);
     await expect(ttPage.dateRolloverBanner).toBeVisible({ timeout: 10000 });
 
     const queueAfterReset = await getQueueSnapshot(page, testUser.repertoireId);
@@ -627,10 +630,7 @@ test.describe("PRACTICE-005: Date Rollover Banner", () => {
         currentDate
       );
 
-      await resetLocalDbAndResync(page);
-      ttPage = new TuneTreesPage(page);
-      await waitForTestApi(page);
-      await expect(ttPage.practiceGrid).toBeVisible({ timeout: 20000 });
+      await resetLocalDbAndReopenPractice(page, testUser.userId);
 
       const repertoireAName = normalizeRepertoireLabel(
         (await ttPage.repertoireDropdownButton.textContent()) || ""
@@ -762,12 +762,7 @@ test.describe("PRACTICE-005: Date Rollover Banner", () => {
     ).toBeNull();
 
     // Resync so the stale row appears in local DB
-    await resetLocalDbAndResync(page);
-    ttPage = new TuneTreesPage(page);
-    await setInjectedTestUserId(page, testUser.userId);
-    await waitForTestApi(page);
-    await ttPage.navigateToTab("practice");
-    await expect(ttPage.practiceGrid).toBeVisible({ timeout: 20000 });
+    await resetLocalDbAndReopenPractice(page, testUser.userId);
 
     // Queue should still be on the current date, not the stale one
     const queueAfterSync = await getQueueSnapshot(page, testUser.repertoireId);
@@ -903,12 +898,7 @@ test.describe("PRACTICE-005: Date Rollover Banner", () => {
     ).toBeNull();
 
     // Resync to pick up the new queue from "another device"
-    await resetLocalDbAndResync(page);
-    ttPage = new TuneTreesPage(page);
-    await setInjectedTestUserId(page, testUser.userId);
-    await waitForTestApi(page);
-    await ttPage.navigateToTab("practice");
-    await expect(ttPage.practiceGrid).toBeVisible({ timeout: 20000 });
+    await resetLocalDbAndReopenPractice(page, testUser.userId);
 
     // The queue date should now be today (matching wall clock) so banner should be hidden
     await expect(ttPage.dateRolloverBanner).toBeHidden({ timeout: 10000 });

--- a/e2e/tests/scheduling-008-interval-ordering.spec.ts
+++ b/e2e/tests/scheduling-008-interval-ordering.spec.ts
@@ -257,7 +257,10 @@ test.describe("SCHEDULING-008: Interval Ordering Across First Evaluations", () =
       await createAndAddToReview(RATED_TUNES[3], "Slip Jig (9/8)");
 
       // Evaluate each tune once with designated rating
-      async function evaluate(meta: RatedTuneMeta) {
+      async function evaluate(
+        meta: RatedTuneMeta,
+        options: { restoreGridModeAfterSubmit: boolean }
+      ) {
         const toastCloser = page.getByRole("button", { name: "Close toast" });
         try {
           const isCloserVisible = await toastCloser.isVisible();
@@ -278,13 +281,22 @@ test.describe("SCHEDULING-008: Interval Ordering Across First Evaluations", () =
         await ttPage.submitEvaluations();
         await page.waitForLoadState("networkidle", { timeout: 15000 });
         await page.waitForTimeout(1500);
-        ttPage.flashcardModeSwitch.isVisible({ timeout: 15000 });
-        await ttPage.disableFlashcardMode();
+
+        // Only return to grid mode when the next loop iteration needs to locate
+        // another tune row in the practice table. After the final submission the
+        // queue is empty, so toggling the flashcard control adds a brittle UI
+        // dependency without affecting the interval-ordering assertion.
+        if (options.restoreGridModeAfterSubmit) {
+          await ttPage.flashcardModeSwitch.isVisible({ timeout: 15000 });
+          await ttPage.disableFlashcardMode();
+        }
         // Interval capture / tuneId resolution will be added later.
       }
 
-      for (const meta of RATED_TUNES) {
-        await evaluate(meta);
+      for (const [index, meta] of RATED_TUNES.entries()) {
+        await evaluate(meta, {
+          restoreGridModeAfterSubmit: index < RATED_TUNES.length - 1,
+        });
       }
 
       // Resolve tune IDs from LOCAL database and query practice records

--- a/oosync.codegen.config.json
+++ b/oosync.codegen.config.json
@@ -18,8 +18,8 @@
     "dbVersionKeyPrefix": "tunetrees-db-version",
     "outboxBackupKeyPrefix": "tunetrees-outbox-backup",
     "lastSyncTimestampKeyPrefix": "TT_LAST_SYNC_TIMESTAMP",
-    "schemaVersion": "2.0.10-add-rhythm-patterns",
-    "databaseVersion": 19,
+    "schemaVersion": "2.0.11-add-rhythm-sample-kit",
+    "databaseVersion": 20,
     "migrationDirectory": "drizzle/migrations/sqlite",
     "migrationFiles": [
       "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",
@@ -41,7 +41,8 @@
       "/drizzle/migrations/sqlite/0016_add_programs.sql",
       "/drizzle/migrations/sqlite/0017_fix_ordered_item_conflict_targets.sql",
       "/drizzle/migrations/sqlite/0018_rename_program_to_setlist.sql",
-      "/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql"
+      "/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql",
+      "/drizzle/migrations/sqlite/0020_add_sample_kit_to_rhythm_patterns.sql"
     ],
     "forceResetQueryParams": [
       { "key": "reset", "value": "true" },

--- a/shared/generated/sync/table-meta.generated.ts
+++ b/shared/generated/sync/table-meta.generated.ts
@@ -403,6 +403,8 @@ export const TABLE_REGISTRY_CORE: Record<SyncableTableName, TableMetaCore> = {
         'Specifies which structural part this pattern targets. "*" or NULL applies to the whole tune, "A" applies only to the A part, "B" to the B part, allowing the groove to change mid-tune.',
       premium_audio_url:
         "Optional URL to a pre-recorded audio loop (e.g., an MP3 hosted on Cloudflare R2). If present, the UI logic should prioritize streaming this file over generating the ABC string.",
+      sample_kit:
+        'The identifier for the audio sample kit used by the frontend registry (e.g., "bodhran", "spoons") to map MIDI pitches to Cloudflare R2 audio URLs.',
       tune_type_id:
         "Foreign key component referencing the tune type (e.g., JigD).",
     },

--- a/shared/table-meta.ts
+++ b/shared/table-meta.ts
@@ -323,6 +323,8 @@ const TABLE_EXTRAS: Record<
         'Specifies which structural part this pattern targets. "*" or NULL applies to the whole tune, "A" applies only to the A part, "B" to the B part, allowing the groove to change mid-tune.',
       premium_audio_url:
         "Optional URL to a pre-recorded audio loop (e.g., an MP3 hosted on Cloudflare R2). If present, the UI logic should prioritize streaming this file over generating the ABC string.",
+      sample_kit:
+        'The identifier for the audio sample kit used by the frontend registry (e.g., "bodhran", "spoons") to map MIDI pitches to Cloudflare R2 audio URLs.',
       tune_type_id:
         "Foreign key component referencing the tune type (e.g., JigD).",
     },

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -275,6 +275,17 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
 
     return ((beatIndex - 1) % beatCountPerBar) + 1;
   });
+  const playbackReadyLabel = createMemo(() => {
+    if (metadata()?.premiumAudioUrl) {
+      return isReady()
+        ? "Premium loop loaded and ready."
+        : "Premium loop loads on first playback.";
+    }
+
+    return isReady()
+      ? "Samples loaded and ready."
+      : "Samples load on first playback.";
+  });
 
   const clearActiveBeatTargets = () => {
     for (const target of activeBeatTargets) {
@@ -510,9 +521,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                   </p>
                 </Show>
                 <p class="text-xs text-slate-500 dark:text-slate-400">
-                  {isReady()
-                    ? "Samples loaded and ready."
-                    : "Samples load on first playback."}
+                  {playbackReadyLabel()}
                 </p>
               </div>
 

--- a/src/lib/db/client-sqlite.ts
+++ b/src/lib/db/client-sqlite.ts
@@ -38,8 +38,8 @@ export const browserSqliteClient = createBrowserSqliteClient({
     outboxBackupKeyPrefix: "tunetrees-outbox-backup",
     lastSyncTimestampKeyPrefix: "TT_LAST_SYNC_TIMESTAMP",
   },
-  databaseVersion: 19,
-  schemaVersion: "2.0.10-add-rhythm-patterns",
+  databaseVersion: 20,
+  schemaVersion: "2.0.11-add-rhythm-sample-kit",
   migrationFiles: [
     "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",
     "/drizzle/migrations/sqlite/0001_thin_chronomancer.sql",
@@ -61,6 +61,7 @@ export const browserSqliteClient = createBrowserSqliteClient({
     "/drizzle/migrations/sqlite/0017_fix_ordered_item_conflict_targets.sql",
     "/drizzle/migrations/sqlite/0018_rename_program_to_setlist.sql",
     "/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql",
+    "/drizzle/migrations/sqlite/0020_add_sample_kit_to_rhythm_patterns.sql",
   ],
   forceResetQueryParams: [
     { key: "reset", value: "true" },

--- a/src/lib/db/migration-version.ts
+++ b/src/lib/db/migration-version.ts
@@ -8,7 +8,7 @@
  * @module lib/db/migration-version
  */
 
-const CURRENT_SCHEMA_VERSION = "2.0.10-add-rhythm-patterns"; // Bump this when schema changes
+const CURRENT_SCHEMA_VERSION = "2.0.11-add-rhythm-sample-kit"; // Bump this when schema changes
 
 /**
  * Get the locally stored schema version from localStorage

--- a/src/lib/services/RhythmService.test.ts
+++ b/src/lib/services/RhythmService.test.ts
@@ -20,22 +20,41 @@ function createDb(sqlStatements: string[]): SqliteDatabase {
   return db as unknown as SqliteDatabase;
 }
 
-function createReferenceRhythmDb() {
+function createPremiumLoopRhythmDb() {
   return createDb([
     "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
     "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
     "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
-    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT)",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran')",
     "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
     "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
     "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
-    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url)
+    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit)
       VALUES ('rp-1', 'ITRAD', 'Reel', 'Basic Rolling', '*', 'X:1
 T:Reel Groove
 M:4/4
 L:1/8
 K:clef=perc
-|: C2 A2 C2 A2 :|', 1, NULL)`,
+|: C2 A2 C2 A2 :|', 1, NULL, 'bodhran')`,
+  ]);
+}
+
+function createSampleKitRhythmDb() {
+  return createDb([
+    "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
+    "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
+    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran')",
+    "INSERT INTO genre (id, name) VALUES ('TEST', 'Session Test')",
+    "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
+    "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('TEST', 'Reel', 112)",
+    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit)
+      VALUES ('rp-1', 'TEST', 'Reel', 'Basic Rolling', '*', 'X:1
+T:Reel Groove
+M:4/4
+L:1/8
+K:clef=perc
+|: C2 A2 C2 A2 :|', 1, NULL, 'bodhran')`,
   ]);
 }
 
@@ -46,12 +65,34 @@ function createFallbackRhythmDb() {
   ]);
 }
 
+function createFallbackJigRhythmDb() {
+  return createDb([
+    "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
+    "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
+    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
+    "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
+    "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Jig', 'Jig', '6/8', 'Jig rhythm')",
+    "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Jig', 115)",
+  ]);
+}
+
+function createFallbackPolkaRhythmDb() {
+  return createDb([
+    "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
+    "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
+    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
+    "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
+    "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Polka', 'Polka', '2/4', 'Polka rhythm')",
+    "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Polka', 120)",
+  ]);
+}
+
 function createRhythmDbWithoutPatternRow() {
   return createDb([
     "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
     "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
     "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
-    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT)",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran')",
     "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
     "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
     "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
@@ -76,65 +117,179 @@ afterEach(() => {
 
 describe("loadRhythmPatternMetadata", () => {
   it("prefers rhythm_patterns and genre_tune_type.default_bpm when available", async () => {
-    const db = createReferenceRhythmDb();
+    const db = createPremiumLoopRhythmDb();
 
-    const metadata = await loadRhythmPatternMetadata(db, {
-      genreName: "Irish Traditional",
-      tuneTypeName: "Reel",
-    });
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
 
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Reel",
       tempoQpm: 112,
-      sampleKit: "bodhran_bosone",
+      sampleKit: "bodhran",
+      premiumAudioSource: "registry",
+      premiumAudioSourceTempoQpm: 110,
       source: "rhythm_patterns",
     });
     expect(metadata?.rhythmAbc).toContain("Reel Groove");
+    expect(metadata?.premiumAudioUrl).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/A4.mp3"
+    );
   });
 
   it("falls back to generated ABC when rhythm_patterns has no matching row", async () => {
     const db = createRhythmDbWithoutPatternRow();
 
-    const metadata = await loadRhythmPatternMetadata(db, {
-      genreName: "Irish Traditional",
-      tuneTypeName: "Reel",
-    });
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
 
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Reel",
       tempoQpm: 112,
-      sampleKit: "bodhran_bosone",
+      sampleKit: "generic_click",
+      premiumAudioSource: "registry",
+      premiumAudioSourceTempoQpm: 110,
       source: "tune_type_fallback",
     });
     expect(metadata?.rhythmAbc).toContain("M:4/4");
+    expect(metadata?.premiumAudioUrl).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/A4.mp3"
+    );
   });
 
   it("falls back when rhythm_patterns exists with an older partial schema", async () => {
     const db = createRhythmDbWithLegacyPatternColumns();
 
-    const metadata = await loadRhythmPatternMetadata(db, {
-      genreName: "Irish Traditional",
-      tuneTypeName: "Reel",
-    });
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
 
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Reel",
       tempoQpm: 112,
-      sampleKit: "bodhran_bosone",
+      sampleKit: "generic_click",
+      premiumAudioSource: "registry",
+      premiumAudioSourceTempoQpm: 110,
       source: "tune_type_fallback",
     });
     expect(metadata?.rhythmAbc).toContain("M:4/4");
+    expect(metadata?.premiumAudioUrl).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/A4.mp3"
+    );
+  });
+
+  it("resolves the nearest uploaded jig premium loop from the registry", async () => {
+    const db = createFallbackJigRhythmDb();
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Jig",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
+
+    expect(metadata).toMatchObject({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Jig",
+      tempoQpm: 115,
+      sampleKit: "generic_click",
+      premiumAudioSource: "registry",
+      premiumAudioSourceTempoQpm: 110,
+      source: "tune_type_fallback",
+    });
+    expect(metadata?.premiumAudioUrl).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/A5.mp3"
+    );
+  });
+
+  it("resolves the uploaded polka premium loop from the registry", async () => {
+    const db = createFallbackPolkaRhythmDb();
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Polka",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
+
+    expect(metadata).toMatchObject({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Polka",
+      tempoQpm: 120,
+      sampleKit: "generic_click",
+      premiumAudioSource: "registry",
+      premiumAudioSourceTempoQpm: 120,
+      source: "tune_type_fallback",
+    });
+    expect(metadata?.premiumAudioUrl).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/F3.mp3"
+    );
+  });
+
+  it("prefixes registry loop URLs with the configured public R2 base URL", async () => {
+    const db = createPremiumLoopRhythmDb();
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+      },
+      {
+        sampleBaseUrl: "https://pub-c77b0e0025a0474588b12433d1a025db.r2.dev",
+      }
+    );
+
+    expect(metadata?.premiumAudioUrl).toBe(
+      "https://pub-c77b0e0025a0474588b12433d1a025db.r2.dev/audio/loops/ITRAD/bodhran/santigaitero/A4.mp3"
+    );
   });
 
   it("falls back to generated percussion ABC and default tempo when new tables are absent", async () => {
     const db = createFallbackRhythmDb();
 
-    const metadata = await loadRhythmPatternMetadata(db, {
-      tuneTypeName: "Reel",
-    });
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        tuneTypeName: "Reel",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
 
     expect(metadata).toMatchObject({
       genreName: null,
@@ -149,8 +304,8 @@ describe("loadRhythmPatternMetadata", () => {
 
 describe("createRhythmService", () => {
   it("plays mapped bodhran samples and restarts timing callbacks when tempo changes", async () => {
-    const db = createReferenceRhythmDb();
-    const fetchMock = vi.fn(async () => ({
+    const db = createSampleKitRhythmDb();
+    const fetchMock = vi.fn(async (_url: string) => ({
       ok: true,
       arrayBuffer: async () => new ArrayBuffer(16),
     }));
@@ -164,6 +319,7 @@ describe("createRhythmService", () => {
     class FakeAudioContext {
       state: AudioContextState = "suspended";
       currentTime = 0;
+      sampleRate = 44_100;
       destination = {};
       resume = vi.fn(async () => {
         this.state = "running";
@@ -174,6 +330,18 @@ describe("createRhythmService", () => {
         numberOfChannels: 1,
         sampleRate: 44_100,
       })) as unknown as typeof AudioContext.prototype.decodeAudioData;
+      createBuffer = vi.fn(
+        (_channels: number, length: number, sampleRate: number) => {
+          const data = new Float32Array(length);
+          return {
+            duration: length / sampleRate,
+            length,
+            numberOfChannels: 1,
+            sampleRate,
+            getChannelData: vi.fn(() => data),
+          } as unknown as AudioBuffer;
+        }
+      );
       createBufferSource = vi.fn(() => {
         const source = {
           buffer: null as AudioBuffer | null,
@@ -276,12 +444,13 @@ describe("createRhythmService", () => {
         db,
         abcjsModule: fakeAbcjs,
         audioContext,
+        sampleBaseUrl: "",
         fetchImpl: fetchMock as unknown as typeof fetch,
       });
     });
 
     const metadata = await service.loadPattern({
-      genreName: "Irish Traditional",
+      genreName: "Session Test",
       tuneTypeName: "Reel",
     });
 
@@ -294,6 +463,8 @@ describe("createRhythmService", () => {
     expect(service.currentBeatIndex()).toBe(1);
     expect(service.currentMeasure()).toBe(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/audio/kits/bodhran/bass.mp3");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/audio/kits/bodhran/rim.mp3");
     expect(bufferSources).toHaveLength(2);
     expect(bufferSources[0]?.start).toHaveBeenCalledTimes(1);
     expect(bufferSources[1]?.start).toHaveBeenCalledTimes(1);
@@ -314,6 +485,349 @@ describe("createRhythmService", () => {
 
     expect(service.isPlaying()).toBe(false);
     expect(FakeTimingCallbacks.instances[1]?.paused).toBe(true);
+
+    dispose();
+  });
+
+  it("plays premium loop audio when a registry-mapped loop exists", async () => {
+    const db = createPremiumLoopRhythmDb();
+    const fetchMock = vi.fn();
+    const createdAudio: Array<{
+      crossOrigin: string | null;
+      currentTime: number;
+      loop: boolean;
+      pause: ReturnType<typeof vi.fn>;
+      play: ReturnType<typeof vi.fn>;
+      playbackRate: number;
+      preload: string;
+      src: string;
+    }> = [];
+
+    class FakeAudioContext {
+      state: AudioContextState = "suspended";
+      currentTime = 0;
+      sampleRate = 44_100;
+      destination = {};
+      resume = vi.fn(async () => {
+        this.state = "running";
+      });
+      decodeAudioData = vi.fn(async () => ({
+        duration: 0.25,
+        length: 1,
+        numberOfChannels: 1,
+        sampleRate: 44_100,
+      })) as unknown as typeof AudioContext.prototype.decodeAudioData;
+      createBuffer = vi.fn(
+        (_channels: number, length: number, sampleRate: number) => {
+          const data = new Float32Array(length);
+          return {
+            duration: length / sampleRate,
+            length,
+            numberOfChannels: 1,
+            sampleRate,
+            getChannelData: vi.fn(() => data),
+          } as unknown as AudioBuffer;
+        }
+      );
+      createBufferSource = vi.fn(() => {
+        throw new Error(
+          "sample buffers should not be used for premium loop playback"
+        );
+      });
+      createGain = vi.fn(
+        () =>
+          ({
+            gain: { value: 1 },
+            connect: vi.fn(),
+          }) as unknown as GainNode
+      );
+      close = vi.fn(async () => {
+        this.state = "closed";
+      });
+    }
+
+    class FakeTimingCallbacks {
+      static instances: FakeTimingCallbacks[] = [];
+      startedWith: Array<{ position?: number; units?: string }> = [];
+      paused = false;
+      currentPositionMs = 0;
+      readonly options: {
+        qpm?: number;
+        beatCallback?: (beatNumber: number) => void;
+        eventCallback?: (event: {
+          type: "event";
+          measureStart: boolean;
+          measureNumber: number;
+          midiPitches: Array<{ pitch: number }>;
+          elements: HTMLElement[][];
+        }) => void;
+      };
+
+      constructor(
+        _visualObj: unknown,
+        options: {
+          qpm?: number;
+          beatCallback?: (beatNumber: number) => void;
+          eventCallback?: (event: {
+            type: "event";
+            measureStart: boolean;
+            measureNumber: number;
+            midiPitches: Array<{ pitch: number }>;
+            elements: HTMLElement[][];
+          }) => void;
+        }
+      ) {
+        this.options = options;
+        FakeTimingCallbacks.instances.push(this);
+      }
+
+      start(position?: number, units?: string) {
+        this.startedWith.push({ position, units });
+        this.currentPositionMs = (position ?? 0) * 1000;
+        this.options.beatCallback?.(1);
+        this.options.eventCallback?.({
+          type: "event",
+          measureStart: true,
+          measureNumber: 1,
+          midiPitches: [{ pitch: 60 }],
+          elements: [[]],
+        });
+      }
+
+      pause() {
+        this.paused = true;
+      }
+
+      reset() {}
+
+      stop() {}
+
+      currentMillisecond() {
+        return this.currentPositionMs;
+      }
+    }
+
+    const fakeAbcjs = {
+      renderAbc: vi.fn(
+        () => [{}] as unknown as ReturnType<typeof import("abcjs").renderAbc>
+      ),
+      TimingCallbacks:
+        FakeTimingCallbacks as unknown as typeof import("abcjs").TimingCallbacks,
+    };
+
+    const audioContext = new FakeAudioContext() as unknown as AudioContext;
+
+    let dispose = () => {};
+    const service = createRoot((nextDispose) => {
+      dispose = nextDispose;
+      return createRhythmService({
+        db,
+        abcjsModule: fakeAbcjs,
+        audioContext,
+        sampleBaseUrl: "",
+        audioElementFactory: (src) => {
+          const element = {
+            crossOrigin: null,
+            currentTime: 0,
+            loop: false,
+            pause: vi.fn(),
+            play: vi.fn(async () => undefined),
+            playbackRate: 1,
+            preload: "none",
+            src,
+          };
+          createdAudio.push(element);
+          return element as unknown as HTMLAudioElement;
+        },
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      });
+    });
+
+    const metadata = await service.loadPattern({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+    });
+
+    expect(metadata?.premiumAudioUrl).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/A4.mp3"
+    );
+
+    await service.play();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(createdAudio).toHaveLength(1);
+    expect(createdAudio[0]?.src).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/A4.mp3"
+    );
+    expect(createdAudio[0]?.loop).toBe(true);
+    expect(createdAudio[0]?.crossOrigin).toBe("anonymous");
+    expect(createdAudio[0]?.preload).toBe("auto");
+    expect(createdAudio[0]?.play).toHaveBeenCalledTimes(1);
+    expect(createdAudio[0]?.playbackRate).toBeCloseTo(112 / 110, 6);
+    expect(service.currentBeatIndex()).toBe(1);
+    expect(service.currentMeasure()).toBe(1);
+
+    FakeTimingCallbacks.instances[0]!.currentPositionMs = 1500;
+    await service.setTempoQpm(132);
+
+    expect(createdAudio).toHaveLength(2);
+    expect(createdAudio[1]?.src).toBe(
+      "/audio/loops/ITRAD/bodhran/santigaitero/C6.mp3"
+    );
+    expect(createdAudio[1]?.playbackRate).toBeCloseTo(132 / 130, 6);
+    expect(FakeTimingCallbacks.instances[1]?.startedWith[0]).toMatchObject({
+      position: 1.5,
+      units: "seconds",
+    });
+
+    service.pause();
+
+    expect(createdAudio[1]?.pause).toHaveBeenCalledTimes(1);
+    expect(service.isPlaying()).toBe(false);
+
+    dispose();
+  });
+
+  it("uses synthesized generic clicks when no uploaded kit applies", async () => {
+    const db = createFallbackRhythmDb();
+    const fetchMock = vi.fn();
+
+    const bufferSources: Array<{
+      buffer: AudioBuffer | null;
+      connect: ReturnType<typeof vi.fn>;
+      start: ReturnType<typeof vi.fn>;
+    }> = [];
+
+    class FakeAudioContext {
+      state: AudioContextState = "suspended";
+      currentTime = 0;
+      sampleRate = 44_100;
+      destination = {};
+      resume = vi.fn(async () => {
+        this.state = "running";
+      });
+      decodeAudioData = vi.fn(async () => ({
+        duration: 0.25,
+        length: 1,
+        numberOfChannels: 1,
+        sampleRate: 44_100,
+      })) as unknown as typeof AudioContext.prototype.decodeAudioData;
+      createBuffer = vi.fn(
+        (_channels: number, length: number, sampleRate: number) => {
+          const data = new Float32Array(length);
+          return {
+            duration: length / sampleRate,
+            length,
+            numberOfChannels: 1,
+            sampleRate,
+            getChannelData: vi.fn(() => data),
+          } as unknown as AudioBuffer;
+        }
+      );
+      createBufferSource = vi.fn(() => {
+        const source = {
+          buffer: null as AudioBuffer | null,
+          connect: vi.fn(),
+          start: vi.fn(),
+        };
+        bufferSources.push(source);
+        return source as unknown as AudioBufferSourceNode;
+      });
+      createGain = vi.fn(
+        () =>
+          ({
+            gain: { value: 1 },
+            connect: vi.fn(),
+          }) as unknown as GainNode
+      );
+      close = vi.fn(async () => {
+        this.state = "closed";
+      });
+    }
+
+    class FakeTimingCallbacks {
+      readonly options: {
+        qpm?: number;
+        beatCallback?: (beatNumber: number) => void;
+        eventCallback?: (event: {
+          type: "event";
+          measureStart: boolean;
+          measureNumber: number;
+          midiPitches: Array<{ pitch: number }>;
+          elements: HTMLElement[][];
+        }) => void;
+      };
+
+      constructor(
+        _visualObj: unknown,
+        options: {
+          qpm?: number;
+          beatCallback?: (beatNumber: number) => void;
+          eventCallback?: (event: {
+            type: "event";
+            measureStart: boolean;
+            measureNumber: number;
+            midiPitches: Array<{ pitch: number }>;
+            elements: HTMLElement[][];
+          }) => void;
+        }
+      ) {
+        this.options = options;
+      }
+
+      start() {
+        this.options.eventCallback?.({
+          type: "event",
+          measureStart: true,
+          measureNumber: 1,
+          midiPitches: [{ pitch: 60 }, { pitch: 69 }],
+          elements: [[]],
+        });
+      }
+
+      pause() {}
+
+      reset() {}
+
+      stop() {}
+
+      currentMillisecond() {
+        return 0;
+      }
+    }
+
+    const fakeAbcjs = {
+      renderAbc: vi.fn(
+        () => [{}] as unknown as ReturnType<typeof import("abcjs").renderAbc>
+      ),
+      TimingCallbacks:
+        FakeTimingCallbacks as unknown as typeof import("abcjs").TimingCallbacks,
+    };
+
+    let dispose = () => {};
+    const service = createRoot((nextDispose) => {
+      dispose = nextDispose;
+      return createRhythmService({
+        db,
+        abcjsModule: fakeAbcjs,
+        audioContext: new FakeAudioContext() as unknown as AudioContext,
+        sampleBaseUrl: "",
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      });
+    });
+
+    const metadata = await service.loadPattern({
+      tuneTypeName: "Reel",
+    });
+
+    expect(metadata?.sampleKit).toBe("generic_click");
+
+    await service.play();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(bufferSources).toHaveLength(2);
+    expect(bufferSources[0]?.start).toHaveBeenCalledTimes(1);
+    expect(bufferSources[1]?.start).toHaveBeenCalledTimes(1);
 
     dispose();
   });

--- a/src/lib/services/RhythmService.test.ts
+++ b/src/lib/services/RhythmService.test.ts
@@ -831,4 +831,290 @@ describe("createRhythmService", () => {
 
     dispose();
   });
+
+  it("falls back to sample-kit audio when premium loop play() rejects", async () => {
+    const db = createPremiumLoopRhythmDb();
+    const fetchMock = vi.fn(async (_url: string) => ({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(16),
+    }));
+
+    const bufferSources: Array<{
+      buffer: AudioBuffer | null;
+      connect: ReturnType<typeof vi.fn>;
+      start: ReturnType<typeof vi.fn>;
+    }> = [];
+
+    class FakeAudioContext {
+      state: AudioContextState = "suspended";
+      currentTime = 0;
+      sampleRate = 44_100;
+      destination = {};
+      resume = vi.fn(async () => {
+        this.state = "running";
+      });
+      decodeAudioData = vi.fn(async () => ({
+        duration: 0.25,
+        length: 1,
+        numberOfChannels: 1,
+        sampleRate: 44_100,
+      })) as unknown as typeof AudioContext.prototype.decodeAudioData;
+      createBuffer = vi.fn(
+        (_channels: number, length: number, sampleRate: number) => {
+          const data = new Float32Array(length);
+          return {
+            duration: length / sampleRate,
+            length,
+            numberOfChannels: 1,
+            sampleRate,
+            getChannelData: vi.fn(() => data),
+          } as unknown as AudioBuffer;
+        }
+      );
+      createBufferSource = vi.fn(() => {
+        const source = {
+          buffer: null as AudioBuffer | null,
+          connect: vi.fn(),
+          start: vi.fn(),
+        };
+        bufferSources.push(source);
+        return source as unknown as AudioBufferSourceNode;
+      });
+      createGain = vi.fn(
+        () =>
+          ({
+            gain: { value: 1 },
+            connect: vi.fn(),
+          }) as unknown as GainNode
+      );
+      close = vi.fn(async () => {
+        this.state = "closed";
+      });
+    }
+
+    class FakeTimingCallbacks {
+      readonly options: {
+        eventCallback?: (event: {
+          type: "event";
+          measureStart: boolean;
+          measureNumber: number;
+          midiPitches: Array<{ pitch: number }>;
+          elements: HTMLElement[][];
+        }) => void;
+      };
+
+      constructor(_visualObj: unknown, options: typeof this.options) {
+        this.options = options;
+      }
+
+      start() {
+        this.options.eventCallback?.({
+          type: "event",
+          measureStart: true,
+          measureNumber: 1,
+          midiPitches: [{ pitch: 60 }, { pitch: 69 }],
+          elements: [[]],
+        });
+      }
+
+      pause() {}
+      reset() {}
+      stop() {}
+      currentMillisecond() {
+        return 0;
+      }
+    }
+
+    const fakeAbcjs = {
+      renderAbc: vi.fn(
+        () => [{}] as unknown as ReturnType<typeof import("abcjs").renderAbc>
+      ),
+      TimingCallbacks:
+        FakeTimingCallbacks as unknown as typeof import("abcjs").TimingCallbacks,
+    };
+
+    const audioContext = new FakeAudioContext() as unknown as AudioContext;
+
+    let dispose = () => {};
+    const service = createRoot((nextDispose) => {
+      dispose = nextDispose;
+      return createRhythmService({
+        db,
+        abcjsModule: fakeAbcjs,
+        audioContext,
+        sampleBaseUrl: "",
+        // Audio element whose play() always rejects to simulate autoplay
+        // denial or network failure.
+        audioElementFactory: (src) =>
+          ({
+            crossOrigin: null,
+            currentTime: 0,
+            loop: false,
+            pause: vi.fn(),
+            play: vi.fn(async () => {
+              throw new Error("NotAllowedError: autoplay blocked");
+            }),
+            playbackRate: 1,
+            preload: "none",
+            src,
+          }) as unknown as HTMLAudioElement,
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      });
+    });
+
+    await service.loadPattern({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+    });
+
+    // Should not throw even though the premium loop play() rejects.
+    await service.play();
+
+    // Fell back to the bodhran sample kit fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/audio/kits/bodhran/bass.mp3");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/audio/kits/bodhran/rim.mp3");
+    // Sample buffers were used to drive the timing callbacks.
+    expect(bufferSources).toHaveLength(2);
+    expect(service.isPlaying()).toBe(true);
+    expect(service.isReady()).toBe(true);
+
+    dispose();
+  });
+
+  it("continues with synthetic clicks when bodhran kit sample fetch fails", async () => {
+    const db = createSampleKitRhythmDb();
+    // Always fail so decodeSample throws for every bodhran file.
+    const fetchMock = vi.fn(async (_url: string) => ({
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    }));
+
+    const bufferSources: Array<{
+      buffer: AudioBuffer | null;
+      connect: ReturnType<typeof vi.fn>;
+      start: ReturnType<typeof vi.fn>;
+    }> = [];
+
+    class FakeAudioContext {
+      state: AudioContextState = "suspended";
+      currentTime = 0;
+      sampleRate = 44_100;
+      destination = {};
+      resume = vi.fn(async () => {
+        this.state = "running";
+      });
+      decodeAudioData = vi.fn(async () => ({
+        duration: 0.25,
+        length: 1,
+        numberOfChannels: 1,
+        sampleRate: 44_100,
+      })) as unknown as typeof AudioContext.prototype.decodeAudioData;
+      createBuffer = vi.fn(
+        (_channels: number, length: number, sampleRate: number) => {
+          const data = new Float32Array(length);
+          return {
+            duration: length / sampleRate,
+            length,
+            numberOfChannels: 1,
+            sampleRate,
+            getChannelData: vi.fn(() => data),
+          } as unknown as AudioBuffer;
+        }
+      );
+      createBufferSource = vi.fn(() => {
+        const source = {
+          buffer: null as AudioBuffer | null,
+          connect: vi.fn(),
+          start: vi.fn(),
+        };
+        bufferSources.push(source);
+        return source as unknown as AudioBufferSourceNode;
+      });
+      createGain = vi.fn(
+        () =>
+          ({
+            gain: { value: 1 },
+            connect: vi.fn(),
+          }) as unknown as GainNode
+      );
+      close = vi.fn(async () => {
+        this.state = "closed";
+      });
+    }
+
+    class FakeTimingCallbacks {
+      readonly options: {
+        eventCallback?: (event: {
+          type: "event";
+          measureStart: boolean;
+          measureNumber: number;
+          midiPitches: Array<{ pitch: number }>;
+          elements: HTMLElement[][];
+        }) => void;
+      };
+
+      constructor(_visualObj: unknown, options: typeof this.options) {
+        this.options = options;
+      }
+
+      start() {
+        this.options.eventCallback?.({
+          type: "event",
+          measureStart: true,
+          measureNumber: 1,
+          midiPitches: [{ pitch: 60 }, { pitch: 69 }],
+          elements: [[]],
+        });
+      }
+
+      pause() {}
+      reset() {}
+      stop() {}
+      currentMillisecond() {
+        return 0;
+      }
+    }
+
+    const fakeAbcjs = {
+      renderAbc: vi.fn(
+        () => [{}] as unknown as ReturnType<typeof import("abcjs").renderAbc>
+      ),
+      TimingCallbacks:
+        FakeTimingCallbacks as unknown as typeof import("abcjs").TimingCallbacks,
+    };
+
+    const audioContext = new FakeAudioContext() as unknown as AudioContext;
+
+    let dispose = () => {};
+    const service = createRoot((nextDispose) => {
+      dispose = nextDispose;
+      return createRhythmService({
+        db,
+        abcjsModule: fakeAbcjs,
+        audioContext,
+        sampleBaseUrl: "",
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      });
+    });
+
+    await service.loadPattern({
+      genreName: "Session Test",
+      tuneTypeName: "Reel",
+    });
+
+    // Should not throw even though all kit fetches fail.
+    await service.play();
+
+    // Fetch was attempted for each bodhran file.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Synthetic fallback buffers were still played via createBufferSource.
+    expect(bufferSources).toHaveLength(2);
+    expect(bufferSources[0]?.start).toHaveBeenCalledTimes(1);
+    expect(bufferSources[1]?.start).toHaveBeenCalledTimes(1);
+    expect(service.isPlaying()).toBe(true);
+    expect(service.isReady()).toBe(true);
+
+    dispose();
+  });
 });

--- a/src/lib/services/RhythmService.ts
+++ b/src/lib/services/RhythmService.ts
@@ -862,23 +862,36 @@ export function createRhythmService(
     }
 
     const audioContext = await ensureAudioContext();
+    // Fallback kit used when a real sample file fails to load or decode.
+    const genericClickKit = SAMPLE_KITS[DEFAULT_SAMPLE_KIT];
     const decodedEntries = await Promise.all(
       Object.entries(kitMapping).map(async ([pitch, entry]) => {
-        const buffer =
-          entry.kind === "file"
-            ? await decodeSample(
-                audioContext,
-                fetchImpl,
-                options.sampleUrlBuilder
-                  ? options.sampleUrlBuilder(activeSampleKit, entry.fileName)
-                  : buildSampleUrl(
-                      sampleBaseUrl,
-                      activeSampleKit,
-                      entry.fileName
-                    )
-              )
-            : createSyntheticClickBuffer(audioContext, entry);
-        return [Number(pitch), buffer] as const;
+        if (entry.kind === "file") {
+          const url = options.sampleUrlBuilder
+            ? options.sampleUrlBuilder(activeSampleKit, entry.fileName)
+            : buildSampleUrl(sampleBaseUrl, activeSampleKit, entry.fileName);
+          try {
+            const buffer = await decodeSample(audioContext, fetchImpl, url);
+            return [Number(pitch), buffer] as const;
+          } catch {
+            // Network or decode failure – substitute a synthetic click for
+            // this pitch so rhythm playback continues without the remote asset.
+            const pitchKey = Number(pitch);
+            const fallback = genericClickKit?.[pitchKey];
+            const syntheticEntry: SampleKitSyntheticEntry =
+              fallback?.kind === "synthetic"
+                ? fallback
+                : { kind: "synthetic", durationMs: 30, frequency: 880 };
+            return [
+              pitchKey,
+              createSyntheticClickBuffer(audioContext, syntheticEntry),
+            ] as const;
+          }
+        }
+        return [
+          Number(pitch),
+          createSyntheticClickBuffer(audioContext, entry),
+        ] as const;
       })
     );
 
@@ -961,13 +974,27 @@ export function createRhythmService(
       throw new Error("Rhythm pattern metadata has not been loaded.");
     }
 
+    let usingPremiumLoop = false;
     const premiumLoopSelection = resolvePremiumLoopSelection(
       currentMetadata,
       tempoQpm()
     );
     if (premiumLoopSelection) {
-      await startPremiumLoopAudio(premiumLoopSelection, tempoQpm(), positionMs);
-    } else {
+      try {
+        await startPremiumLoopAudio(
+          premiumLoopSelection,
+          tempoQpm(),
+          positionMs
+        );
+        usingPremiumLoop = true;
+      } catch {
+        // Premium loop unavailable (e.g. 404, CORS, autoplay rejection) –
+        // clean up and fall through to the WebAudio sample path so rhythm
+        // playback continues.
+        stopPremiumLoopAudio(true);
+      }
+    }
+    if (!usingPremiumLoop) {
       await ensureSamplesLoaded();
     }
 
@@ -980,7 +1007,7 @@ export function createRhythmService(
     timingCallbacks = buildTimingCallbacks(
       currentMetadata.rhythmAbc,
       audioContext,
-      premiumLoopSelection == null
+      !usingPremiumLoop
     );
     timingCallbacks.start(
       positionMs == null ? undefined : msToSeconds(positionMs),

--- a/src/lib/services/RhythmService.ts
+++ b/src/lib/services/RhythmService.ts
@@ -8,8 +8,10 @@ import { sql } from "drizzle-orm";
 import { type Accessor, createSignal, onCleanup } from "solid-js";
 import type { SqliteDatabase } from "@/lib/db/client-sqlite";
 
-const DEFAULT_SAMPLE_BASE_URL = "/samples/bodhran";
-const DEFAULT_SAMPLE_KIT = "bodhran_bosone";
+const DEFAULT_SAMPLE_BASE_URL = (
+  import.meta.env.VITE_R2_AUDIO_BASE_URL?.trim() ?? ""
+).replace(/\/+$/, "");
+const DEFAULT_SAMPLE_KIT = "generic_click";
 const REQUIRED_RHYTHM_PATTERN_COLUMNS = [
   "abc_string",
   "genre_id",
@@ -18,10 +20,123 @@ const REQUIRED_RHYTHM_PATTERN_COLUMNS = [
   "part_target",
   "tune_type_id",
 ] as const;
-const SAMPLE_FILE_BY_PITCH: Record<number, string> = {
-  60: "bass.mp3",
-  69: "rim.mp3",
+
+type SampleKitFileEntry = {
+  kind: "file";
+  fileName: string;
 };
+
+type SampleKitSyntheticEntry = {
+  kind: "synthetic";
+  durationMs: number;
+  frequency: number;
+};
+
+type SampleKitEntry = SampleKitFileEntry | SampleKitSyntheticEntry;
+
+type PremiumLoopEntry = {
+  tempoQpm: number;
+  fileName: string;
+  trimMs: number;
+};
+
+type PremiumLoopLibrary = {
+  genreId: string;
+  sampleKit: string;
+  performerSlug: string;
+  entries: readonly PremiumLoopEntry[];
+};
+
+type PremiumLoopSelection = {
+  source: "database" | "registry";
+  url: string;
+  sourceTempoQpm: number | null;
+  trimMs: number;
+};
+
+type PremiumLoopAudio = Pick<
+  HTMLAudioElement,
+  | "crossOrigin"
+  | "currentTime"
+  | "loop"
+  | "pause"
+  | "play"
+  | "playbackRate"
+  | "preload"
+  | "src"
+>;
+
+const SAMPLE_KITS: Record<string, Record<number, SampleKitEntry>> = {
+  bodhran: {
+    60: { kind: "file", fileName: "bass.mp3" },
+    69: { kind: "file", fileName: "rim.mp3" },
+  },
+  generic_click: {
+    60: { kind: "synthetic", durationMs: 30, frequency: 1760 },
+    69: { kind: "synthetic", durationMs: 20, frequency: 880 },
+  },
+};
+
+const PREMIUM_LOOP_LIBRARY: Record<string, PremiumLoopLibrary> = {
+  "irish traditional::reel": {
+    genreId: "ITRAD",
+    sampleKit: "bodhran",
+    performerSlug: "santigaitero",
+    entries: [
+      { tempoQpm: 50, fileName: "C4.mp3", trimMs: 0 },
+      { tempoQpm: 55, fileName: "Db4.mp3", trimMs: 0 },
+      { tempoQpm: 60, fileName: "D4.mp3", trimMs: 0 },
+      { tempoQpm: 65, fileName: "Eb4.mp3", trimMs: 0 },
+      { tempoQpm: 70, fileName: "E4.mp3", trimMs: 0 },
+      { tempoQpm: 75, fileName: "F4.mp3", trimMs: 0 },
+      { tempoQpm: 80, fileName: "Gb4.mp3", trimMs: 0 },
+      { tempoQpm: 90, fileName: "G4.mp3", trimMs: 0 },
+      { tempoQpm: 100, fileName: "Ab4.mp3", trimMs: 0 },
+      { tempoQpm: 110, fileName: "A4.mp3", trimMs: 0 },
+      { tempoQpm: 120, fileName: "Bb4.mp3", trimMs: 0 },
+      { tempoQpm: 130, fileName: "C6.mp3", trimMs: 0 },
+      { tempoQpm: 140, fileName: "Db6.mp3", trimMs: 0 },
+    ],
+  },
+  "irish traditional::jig": {
+    genreId: "ITRAD",
+    sampleKit: "bodhran",
+    performerSlug: "santigaitero",
+    entries: [
+      { tempoQpm: 50, fileName: "C5.mp3", trimMs: 0 },
+      { tempoQpm: 55, fileName: "Db5.mp3", trimMs: 0 },
+      { tempoQpm: 60, fileName: "D5.mp3", trimMs: 0 },
+      { tempoQpm: 65, fileName: "Eb5.mp3", trimMs: 0 },
+      { tempoQpm: 70, fileName: "E5.mp3", trimMs: 0 },
+      { tempoQpm: 75, fileName: "F5.mp3", trimMs: 0 },
+      { tempoQpm: 80, fileName: "Gb5.mp3", trimMs: 0 },
+      { tempoQpm: 90, fileName: "G5.mp3", trimMs: 0 },
+      { tempoQpm: 100, fileName: "Ab5.mp3", trimMs: 0 },
+      { tempoQpm: 110, fileName: "A5.mp3", trimMs: 0 },
+      { tempoQpm: 120, fileName: "Bb5.mp3", trimMs: 0 },
+      { tempoQpm: 130, fileName: "D6.mp3", trimMs: 0 },
+      { tempoQpm: 140, fileName: "Eb6.mp3", trimMs: 0 },
+    ],
+  },
+  "irish traditional::polka": {
+    genreId: "ITRAD",
+    sampleKit: "bodhran",
+    performerSlug: "santigaitero",
+    entries: [
+      { tempoQpm: 70, fileName: "C3.mp3", trimMs: 0 },
+      { tempoQpm: 80, fileName: "Db3.mp3", trimMs: 0 },
+      { tempoQpm: 90, fileName: "D3.mp3", trimMs: 0 },
+      { tempoQpm: 100, fileName: "Eb3.mp3", trimMs: 0 },
+      { tempoQpm: 110, fileName: "E3.mp3", trimMs: 0 },
+      { tempoQpm: 120, fileName: "F3.mp3", trimMs: 0 },
+      { tempoQpm: 130, fileName: "Gb3.mp3", trimMs: 0 },
+      { tempoQpm: 140, fileName: "G3.mp3", trimMs: 0 },
+      { tempoQpm: 150, fileName: "E6.mp3", trimMs: 0 },
+      { tempoQpm: 160, fileName: "F6.mp3", trimMs: 0 },
+    ],
+  },
+};
+
 const DEFAULT_TEMPO_BY_TYPE: Record<string, number> = {
   reel: 100,
   hornpipe: 90,
@@ -44,6 +159,10 @@ export interface RhythmPatternMetadata {
   tuneStructure?: string | null;
   tempoQpm: number;
   sampleKit: string;
+  premiumAudioUrl: string | null;
+  premiumAudioTrimMs: number;
+  premiumAudioSource: "database" | "registry" | null;
+  premiumAudioSourceTempoQpm: number | null;
   source: "rhythm_patterns" | "tune_type_fallback";
 }
 
@@ -70,6 +189,7 @@ export interface CreateRhythmServiceOptions {
   db: SqliteDatabase;
   abcjsModule?: Pick<typeof abcjs, "renderAbc" | "TimingCallbacks">;
   audioContext?: AudioContext;
+  audioElementFactory?: (sourceUrl: string) => PremiumLoopAudio;
   fetchImpl?: typeof fetch;
   sampleBaseUrl?: string;
   sampleUrlBuilder?: (sampleKit: string, fileName: string) => string;
@@ -84,6 +204,10 @@ type TimingCallbacksInstance = InstanceType<
 
 function normalizeTuneTypeName(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function normalizeGenreName(value?: string | null): string {
+  return value?.trim().toLowerCase() ?? "";
 }
 
 function sanitizeAbcTitle(value: string): string {
@@ -116,6 +240,112 @@ async function getTableColumns(
 
 function getDefaultTempoForTuneType(tuneTypeName: string): number {
   return DEFAULT_TEMPO_BY_TYPE[normalizeTuneTypeName(tuneTypeName)] ?? 100;
+}
+
+function normalizeSampleKit(sampleKit?: string | null): string {
+  return sampleKit?.trim() || DEFAULT_SAMPLE_KIT;
+}
+
+function getSampleKitMapping(
+  sampleKit?: string | null
+): Record<number, SampleKitEntry> {
+  return (
+    SAMPLE_KITS[normalizeSampleKit(sampleKit)] ??
+    SAMPLE_KITS[DEFAULT_SAMPLE_KIT]
+  );
+}
+
+function buildSampleUrl(
+  baseUrl: string,
+  sampleKit: string,
+  fileName: string
+): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, "");
+  const assetPath = `audio/kits/${sampleKit}/${fileName}`;
+  return normalizedBase ? `${normalizedBase}/${assetPath}` : `/${assetPath}`;
+}
+
+function buildPremiumLoopUrl(
+  baseUrl: string,
+  library: PremiumLoopLibrary,
+  fileName: string
+): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, "");
+  const assetPath = `audio/loops/${library.genreId}/${library.sampleKit}/${library.performerSlug}/${fileName}`;
+  return normalizedBase ? `${normalizedBase}/${assetPath}` : `/${assetPath}`;
+}
+
+function normalizePremiumAudioUrl(baseUrl: string, value: string): string {
+  const trimmed = value.trim();
+  if (/^https?:\/\//i.test(trimmed) || trimmed.startsWith("/")) {
+    return trimmed;
+  }
+
+  const normalizedBase = baseUrl.replace(/\/+$/, "");
+  return normalizedBase ? `${normalizedBase}/${trimmed}` : `/${trimmed}`;
+}
+
+function selectNearestPremiumLoopEntry(
+  entries: readonly PremiumLoopEntry[],
+  targetTempoQpm: number
+): PremiumLoopEntry | null {
+  const [selected] = [...entries].sort((left, right) => {
+    const leftDelta = Math.abs(left.tempoQpm - targetTempoQpm);
+    const rightDelta = Math.abs(right.tempoQpm - targetTempoQpm);
+
+    if (leftDelta !== rightDelta) {
+      return leftDelta - rightDelta;
+    }
+
+    return left.tempoQpm - right.tempoQpm;
+  });
+
+  return selected ?? null;
+}
+
+function selectPremiumLoop(
+  sampleBaseUrl: string,
+  request: {
+    explicitUrl?: string | null;
+    genreName?: string | null;
+    tuneTypeName: string;
+    tempoQpm: number;
+  }
+): PremiumLoopSelection | null {
+  const explicitUrl = request.explicitUrl?.trim();
+  if (explicitUrl) {
+    return {
+      source: "database",
+      url: normalizePremiumAudioUrl(sampleBaseUrl, explicitUrl),
+      sourceTempoQpm: request.tempoQpm,
+      trimMs: 0,
+    };
+  }
+
+  const library =
+    PREMIUM_LOOP_LIBRARY[
+      `${normalizeGenreName(request.genreName)}::${normalizeTuneTypeName(
+        request.tuneTypeName
+      )}`
+    ];
+  if (!library) {
+    return null;
+  }
+
+  const entry = selectNearestPremiumLoopEntry(
+    library.entries,
+    request.tempoQpm
+  );
+  if (!entry) {
+    return null;
+  }
+
+  return {
+    source: "registry",
+    url: buildPremiumLoopUrl(sampleBaseUrl, library, entry.fileName),
+    sourceTempoQpm: entry.tempoQpm,
+    trimMs: entry.trimMs,
+  };
 }
 
 function msToSeconds(value: number): number {
@@ -165,7 +395,8 @@ function buildFallbackRhythmAbc(
 
 export async function loadRhythmPatternMetadata(
   db: SqliteDatabase,
-  request: RhythmPatternRequest
+  request: RhythmPatternRequest,
+  options?: { sampleBaseUrl?: string }
 ): Promise<RhythmPatternMetadata | null> {
   const tuneTypeName = request.tuneTypeName?.trim();
   if (!tuneTypeName) {
@@ -186,6 +417,10 @@ export async function loadRhythmPatternMetadata(
     REQUIRED_RHYTHM_PATTERN_COLUMNS.every((column) =>
       rhythmPatternColumns.has(column)
     );
+  const hasSampleKitColumn = rhythmPatternColumns.has("sample_kit");
+  const hasPremiumAudioUrlColumn =
+    rhythmPatternColumns.has("premium_audio_url");
+  const sampleBaseUrl = options?.sampleBaseUrl ?? DEFAULT_SAMPLE_BASE_URL;
 
   const genreFilter = request.genreName?.trim() || null;
 
@@ -196,6 +431,8 @@ export async function loadRhythmPatternMetadata(
       rhythm_signature: string | null;
       tempo_qpm: number | null;
       abc_string: string | null;
+      sample_kit: string | null;
+      premium_audio_url: string | null;
     }>(sql`
       WITH tune_type_match AS (
         SELECT id, name, rhythm
@@ -215,6 +452,14 @@ export async function loadRhythmPatternMetadata(
           rp.genre_id,
           rp.tune_type_id,
           rp.abc_string,
+          ${
+            hasSampleKitColumn ? sql`rp.sample_kit` : sql`CAST(NULL AS TEXT)`
+          } AS sample_kit,
+          ${
+            hasPremiumAudioUrlColumn
+              ? sql`rp.premium_audio_url`
+              : sql`CAST(NULL AS TEXT)`
+          } AS premium_audio_url,
           rp.is_default,
           rp.part_target,
           ROW_NUMBER() OVER (
@@ -240,7 +485,9 @@ export async function loadRhythmPatternMetadata(
             ? sql`gtt.default_bpm`
             : sql`CAST(NULL AS INTEGER)`
         } AS tempo_qpm,
-        sp.abc_string AS abc_string
+        sp.abc_string AS abc_string,
+        sp.sample_kit AS sample_kit,
+        sp.premium_audio_url AS premium_audio_url
       FROM tune_type_match ttm
       LEFT JOIN genre_match gm ON 1 = 1
       LEFT JOIN genre_tune_type gtt
@@ -252,16 +499,28 @@ export async function loadRhythmPatternMetadata(
 
     const row = rows[0];
     if (row?.tune_type_name && row.abc_string?.trim()) {
+      const resolvedTempoQpm =
+        typeof row.tempo_qpm === "number" && Number.isFinite(row.tempo_qpm)
+          ? row.tempo_qpm
+          : getDefaultTempoForTuneType(row.tune_type_name);
+      const premiumLoop = selectPremiumLoop(sampleBaseUrl, {
+        explicitUrl: row.premium_audio_url,
+        genreName: row.genre_name ?? genreFilter,
+        tuneTypeName: row.tune_type_name,
+        tempoQpm: resolvedTempoQpm,
+      });
+
       return {
         genreName: row.genre_name ?? genreFilter,
         tuneTypeName: row.tune_type_name,
         rhythmSignature: row.rhythm_signature ?? null,
         rhythmAbc: row.abc_string.trim(),
-        tempoQpm:
-          typeof row.tempo_qpm === "number" && Number.isFinite(row.tempo_qpm)
-            ? row.tempo_qpm
-            : getDefaultTempoForTuneType(row.tune_type_name),
-        sampleKit: DEFAULT_SAMPLE_KIT,
+        tempoQpm: resolvedTempoQpm,
+        sampleKit: normalizeSampleKit(row.sample_kit),
+        premiumAudioUrl: premiumLoop?.url ?? null,
+        premiumAudioTrimMs: premiumLoop?.trimMs ?? 0,
+        premiumAudioSource: premiumLoop?.source ?? null,
+        premiumAudioSourceTempoQpm: premiumLoop?.sourceTempoQpm ?? null,
         source: "rhythm_patterns",
       };
     }
@@ -302,6 +561,16 @@ export async function loadRhythmPatternMetadata(
 
     const row = rows[0];
     if (row?.tune_type_name) {
+      const resolvedTempoQpm =
+        typeof row.tempo_qpm === "number" && Number.isFinite(row.tempo_qpm)
+          ? row.tempo_qpm
+          : getDefaultTempoForTuneType(row.tune_type_name);
+      const premiumLoop = selectPremiumLoop(sampleBaseUrl, {
+        genreName: row.genre_name ?? genreFilter,
+        tuneTypeName: row.tune_type_name,
+        tempoQpm: resolvedTempoQpm,
+      });
+
       return {
         genreName: row.genre_name ?? genreFilter,
         tuneTypeName: row.tune_type_name,
@@ -310,11 +579,12 @@ export async function loadRhythmPatternMetadata(
           row.tune_type_name,
           row.rhythm_signature ?? null
         ),
-        tempoQpm:
-          typeof row.tempo_qpm === "number" && Number.isFinite(row.tempo_qpm)
-            ? row.tempo_qpm
-            : getDefaultTempoForTuneType(row.tune_type_name),
+        tempoQpm: resolvedTempoQpm,
         sampleKit: DEFAULT_SAMPLE_KIT,
+        premiumAudioUrl: premiumLoop?.url ?? null,
+        premiumAudioTrimMs: premiumLoop?.trimMs ?? 0,
+        premiumAudioSource: premiumLoop?.source ?? null,
+        premiumAudioSourceTempoQpm: premiumLoop?.sourceTempoQpm ?? null,
         source: "tune_type_fallback",
       };
     }
@@ -345,6 +615,10 @@ export async function loadRhythmPatternMetadata(
     ),
     tempoQpm: getDefaultTempoForTuneType(fallbackRow.tune_type_name),
     sampleKit: DEFAULT_SAMPLE_KIT,
+    premiumAudioUrl: null,
+    premiumAudioTrimMs: 0,
+    premiumAudioSource: null,
+    premiumAudioSourceTempoQpm: null,
     source: "tune_type_fallback",
   };
 }
@@ -370,6 +644,26 @@ function getAudioContextConstructor(): (new () => AudioContext) | undefined {
   );
 }
 
+function getAudioElementConstructor():
+  | (new (
+      src?: string
+    ) => HTMLAudioElement)
+  | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return window.Audio;
+}
+
+function clampPremiumLoopPlaybackRate(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 1;
+  }
+
+  return Math.min(2, Math.max(0.5, value));
+}
+
 async function decodeSample(
   audioContext: AudioContext,
   fetchImpl: typeof fetch,
@@ -382,6 +676,31 @@ async function decodeSample(
 
   const buffer = await response.arrayBuffer();
   return await audioContext.decodeAudioData(buffer);
+}
+
+function createSyntheticClickBuffer(
+  audioContext: AudioContext,
+  entry: SampleKitSyntheticEntry
+): AudioBuffer {
+  const frameCount = Math.max(
+    1,
+    Math.round((audioContext.sampleRate * entry.durationMs) / 1000)
+  );
+  const buffer = audioContext.createBuffer(
+    1,
+    frameCount,
+    audioContext.sampleRate
+  );
+  const channelData = buffer.getChannelData(0);
+
+  for (let index = 0; index < frameCount; index += 1) {
+    const time = index / audioContext.sampleRate;
+    const envelope = Math.exp((-8 * index) / frameCount);
+    channelData[index] =
+      Math.sin(2 * Math.PI * entry.frequency * time) * envelope;
+  }
+
+  return buffer;
 }
 
 function getPitchPlaybackGain(event: NoteTimingEvent): number {
@@ -415,15 +734,103 @@ export function createRhythmService(
   let lastKnownPositionMs = 0;
   let ownedAudioContext: AudioContext | null = null;
   let sampleBuffers = new Map<number, AudioBuffer>();
+  let loadedSampleKit: string | null = null;
+  let premiumLoopAudio: PremiumLoopAudio | null = null;
+  let premiumLoopUrl: string | null = null;
   let renderTarget: HTMLDivElement | null = null;
 
-  const stopPlayback = () => {
+  const stopPremiumLoopAudio = (resetPosition: boolean) => {
+    if (!premiumLoopAudio) {
+      if (resetPosition) {
+        premiumLoopUrl = null;
+      }
+      return;
+    }
+
+    premiumLoopAudio.pause();
+    if (resetPosition) {
+      premiumLoopAudio.currentTime = 0;
+      premiumLoopAudio = null;
+      premiumLoopUrl = null;
+    }
+  };
+
+  const stopPlayback = (resetPosition = true) => {
     if (timingCallbacks) {
       timingCallbacks.stop();
       timingCallbacks = null;
     }
+    stopPremiumLoopAudio(resetPosition);
     setIsPlaying(false);
   };
+
+  function resolvePremiumLoopSelection(
+    currentMetadata: RhythmPatternMetadata,
+    targetTempoQpm: number
+  ): PremiumLoopSelection | null {
+    if (currentMetadata.premiumAudioSource === "database") {
+      return currentMetadata.premiumAudioUrl
+        ? {
+            source: "database",
+            url: currentMetadata.premiumAudioUrl,
+            sourceTempoQpm:
+              currentMetadata.premiumAudioSourceTempoQpm ??
+              currentMetadata.tempoQpm,
+            trimMs: currentMetadata.premiumAudioTrimMs,
+          }
+        : null;
+    }
+
+    return selectPremiumLoop(sampleBaseUrl, {
+      genreName: currentMetadata.genreName,
+      tuneTypeName: currentMetadata.tuneTypeName,
+      tempoQpm: targetTempoQpm,
+    });
+  }
+
+  function createPremiumLoopAudio(sourceUrl: string): PremiumLoopAudio {
+    if (options.audioElementFactory) {
+      return options.audioElementFactory(sourceUrl);
+    }
+
+    const AudioConstructor = getAudioElementConstructor();
+    if (!AudioConstructor) {
+      throw new Error(
+        "HTML audio playback is not available in this environment."
+      );
+    }
+
+    return new AudioConstructor(sourceUrl);
+  }
+
+  async function startPremiumLoopAudio(
+    selection: PremiumLoopSelection,
+    targetTempoQpm: number,
+    positionMs?: number
+  ): Promise<void> {
+    if (!premiumLoopAudio || premiumLoopUrl !== selection.url) {
+      stopPremiumLoopAudio(true);
+      premiumLoopAudio = createPremiumLoopAudio(selection.url);
+      premiumLoopUrl = selection.url;
+    }
+
+    premiumLoopAudio.loop = true;
+    premiumLoopAudio.preload = "auto";
+    premiumLoopAudio.crossOrigin = "anonymous";
+    premiumLoopAudio.playbackRate = clampPremiumLoopPlaybackRate(
+      targetTempoQpm / Math.max(1, selection.sourceTempoQpm ?? targetTempoQpm)
+    );
+    if (positionMs != null) {
+      premiumLoopAudio.currentTime = msToSeconds(
+        Math.max(0, positionMs + selection.trimMs)
+      );
+    } else if (selection.trimMs > 0 && premiumLoopAudio.currentTime === 0) {
+      premiumLoopAudio.currentTime = msToSeconds(selection.trimMs);
+    }
+
+    await premiumLoopAudio.play();
+    setIsReady(true);
+  }
 
   async function ensureAudioContext(): Promise<AudioContext> {
     if (options.audioContext) {
@@ -443,26 +850,40 @@ export function createRhythmService(
   }
 
   async function ensureSamplesLoaded(): Promise<void> {
-    if (sampleBuffers.size === Object.keys(SAMPLE_FILE_BY_PITCH).length) {
+    const activeSampleKit = normalizeSampleKit(metadata()?.sampleKit);
+    const kitMapping = getSampleKitMapping(activeSampleKit);
+
+    if (
+      loadedSampleKit === activeSampleKit &&
+      sampleBuffers.size === Object.keys(kitMapping).length
+    ) {
       setIsReady(true);
       return;
     }
 
     const audioContext = await ensureAudioContext();
     const decodedEntries = await Promise.all(
-      Object.entries(SAMPLE_FILE_BY_PITCH).map(async ([pitch, fileName]) => {
-        const buffer = await decodeSample(
-          audioContext,
-          fetchImpl,
-          options.sampleUrlBuilder
-            ? options.sampleUrlBuilder(DEFAULT_SAMPLE_KIT, fileName)
-            : `${sampleBaseUrl}/${fileName}`
-        );
+      Object.entries(kitMapping).map(async ([pitch, entry]) => {
+        const buffer =
+          entry.kind === "file"
+            ? await decodeSample(
+                audioContext,
+                fetchImpl,
+                options.sampleUrlBuilder
+                  ? options.sampleUrlBuilder(activeSampleKit, entry.fileName)
+                  : buildSampleUrl(
+                      sampleBaseUrl,
+                      activeSampleKit,
+                      entry.fileName
+                    )
+              )
+            : createSyntheticClickBuffer(audioContext, entry);
         return [Number(pitch), buffer] as const;
       })
     );
 
     sampleBuffers = new Map(decodedEntries);
+    loadedSampleKit = activeSampleKit;
     setIsReady(true);
   }
 
@@ -493,7 +914,8 @@ export function createRhythmService(
 
   function buildTimingCallbacks(
     rhythmAbc: string,
-    audioContext: AudioContext
+    audioContext: AudioContext,
+    shouldPlayEventSamples: boolean
   ): TimingCallbacksInstance {
     if (typeof document === "undefined") {
       throw new Error("ABC rhythm playback requires a browser document.");
@@ -524,7 +946,9 @@ export function createRhythmService(
         if (event.measureStart) {
           setCurrentMeasure(event.measureNumber ?? currentMeasure());
         }
-        playEventPitches(event, audioContext);
+        if (shouldPlayEventSamples) {
+          playEventPitches(event, audioContext);
+        }
       },
     };
 
@@ -537,7 +961,16 @@ export function createRhythmService(
       throw new Error("Rhythm pattern metadata has not been loaded.");
     }
 
-    await ensureSamplesLoaded();
+    const premiumLoopSelection = resolvePremiumLoopSelection(
+      currentMetadata,
+      tempoQpm()
+    );
+    if (premiumLoopSelection) {
+      await startPremiumLoopAudio(premiumLoopSelection, tempoQpm(), positionMs);
+    } else {
+      await ensureSamplesLoaded();
+    }
+
     const audioContext = await ensureAudioContext();
     if (audioContext.state === "suspended") {
       await audioContext.resume();
@@ -546,7 +979,8 @@ export function createRhythmService(
     timingCallbacks?.stop();
     timingCallbacks = buildTimingCallbacks(
       currentMetadata.rhythmAbc,
-      audioContext
+      audioContext,
+      premiumLoopSelection == null
     );
     timingCallbacks.start(
       positionMs == null ? undefined : msToSeconds(positionMs),
@@ -564,10 +998,13 @@ export function createRhythmService(
     setCurrentMeasure(0);
     setError(null);
 
-    const nextMetadata = await loadRhythmPatternMetadata(options.db, request);
+    const nextMetadata = await loadRhythmPatternMetadata(options.db, request, {
+      sampleBaseUrl,
+    });
     setMetadata(nextMetadata);
     if (nextMetadata) {
       setTempoQpmSignal(clampTempo(nextMetadata.tempoQpm));
+      setIsReady(false);
     }
 
     return nextMetadata;
@@ -580,12 +1017,14 @@ export function createRhythmService(
 
   function pause(): void {
     if (!timingCallbacks) {
+      stopPremiumLoopAudio(false);
       setIsPlaying(false);
       return;
     }
 
     lastKnownPositionMs = timingCallbacks.currentMillisecond();
     timingCallbacks.pause();
+    stopPremiumLoopAudio(false);
     setIsPlaying(false);
   }
 

--- a/supabase/migrations/20260512000000_add_sample_kit_to_rhythm_patterns.sql
+++ b/supabase/migrations/20260512000000_add_sample_kit_to_rhythm_patterns.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE public.rhythm_patterns
+ADD COLUMN sample_kit TEXT NOT NULL DEFAULT 'bodhran';
+
+COMMENT ON COLUMN public.rhythm_patterns.sample_kit IS 'The identifier for the audio sample kit used by the frontend registry (e.g., "bodhran", "spoons") to map MIDI pitches to Cloudflare R2 audio URLs.';
+
+COMMIT;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(() => {
   const showWorkboxLogs = process.env.VITE_WORKBOX_DEBUG === "true";
   const disableHmrForE2E = process.env.VITE_DISABLE_HMR_FOR_E2E === "true";
   const MEDIA_AUTH_TOKEN_QUERY_PARAM = "token";
+  const rhythmAssetsBaseUrl = process.env.VITE_R2_AUDIO_BASE_URL?.trim() ?? "";
   const e2eArtifactWatchIgnore = [
     "**/logs/**",
     "**/test-results/**",
@@ -86,6 +87,28 @@ export default defineConfig(() => {
       }
       return url.toString();
     },
+  };
+
+  const matchesRhythmAssetUrl = ({ url }: { url: URL }) => {
+    const normalizedPath = url.pathname.replace(/\/+$/, "");
+    const isKnownRhythmAssetPath =
+      normalizedPath.startsWith("/audio/kits/") ||
+      normalizedPath.startsWith("/audio/loops/");
+
+    if (!isKnownRhythmAssetPath) {
+      return false;
+    }
+
+    if (!rhythmAssetsBaseUrl) {
+      return true;
+    }
+
+    try {
+      const configuredBase = new URL(rhythmAssetsBaseUrl);
+      return url.origin === configuredBase.origin;
+    } catch {
+      return true;
+    }
   };
 
   return {
@@ -245,6 +268,23 @@ export default defineConfig(() => {
                 expiration: {
                   maxEntries: 100,
                   maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
+                },
+              },
+            },
+            {
+              urlPattern: matchesRhythmAssetUrl,
+              // Rhythm assets are immutable kit/loop files hosted outside the
+              // app bundle. Cache the first successful fetch so they remain
+              // playable offline after initial load.
+              handler: "CacheFirst",
+              options: {
+                cacheName: "rhythm-audio-cache",
+                cacheableResponse: {
+                  statuses: [200],
+                },
+                expiration: {
+                  maxEntries: 128,
+                  maxAgeSeconds: 60 * 60 * 24 * 365,
                 },
               },
             },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,14 +100,17 @@ export default defineConfig(() => {
     }
 
     if (!rhythmAssetsBaseUrl) {
-      return true;
+      // No R2 base URL configured – restrict to same-origin only so we don't
+      // accidentally CacheFirst arbitrary cross-origin /audio/kits or /audio/loops URLs.
+      return url.origin === self.location.origin;
     }
 
     try {
       const configuredBase = new URL(rhythmAssetsBaseUrl);
       return url.origin === configuredBase.origin;
     } catch {
-      return true;
+      // Unparseable base URL – fall back to same-origin only.
+      return url.origin === self.location.origin;
     }
   };
 

--- a/worker/src/generated/schema-postgres.generated.ts
+++ b/worker/src/generated/schema-postgres.generated.ts
@@ -330,6 +330,7 @@ export const rhythmPatterns = pgTable("rhythm_patterns", {
   abcString: text("abc_string").notNull(),
   isDefault: boolean("is_default").notNull().default(false),
   premiumAudioUrl: text("premium_audio_url"),
+  sampleKit: text("sample_kit").notNull().default("bodhran"),
 });
 
 export const setlist = pgTable("setlist", {


### PR DESCRIPTION
## Summary

This PR delivers one mergeable slice of #607.

Related to #607.

Note: this PR advances #607 but does not close it.

## Advances #607

- adds `sample_kit` support to `rhythm_patterns` across Supabase, SQLite, and generated sync metadata so rhythm assets can be selected by registry instead of hardcoded URLs
- adds registry-driven rhythm asset loading in `RhythmService`, including public R2-backed bodhran single hits, premium loop selection by tune type/tempo, generic click fallback, and offline caching for rhythm assets

## Not in this PR

- seeding explicit `premium_audio_url` rows in the database
- completing the rest of the #607 umbrella work beyond this rhythm-accompaniment asset slice

## Merge safety

This is safe to merge now because:
- the change is additive at the schema level and preserves fallback behavior when rhythm pattern rows or newer columns are absent
- the runtime keeps a non-premium fallback path via generated ABC percussion and synthetic clicks if uploaded assets are unavailable
- the branch passed the standard local quality gate suite before opening the PR

## Review focus

- `RhythmService` registry behavior: sample-kit mapping, premium-loop selection, URL resolution, and fallback behavior
- schema/codegen consistency for the new `sample_kit` column across Supabase, SQLite, and generated artifacts
- the two targeted Playwright spec stabilizations included in this branch (`SCHEDULING-008` and `PRACTICE-005`)

## Validation

- `npm run lint && npm run check && npm run typecheck && npm run test:unit`
- verified codegen/schema artifacts with `npm run codegen:schema:check` and regenerated schema outputs locally

## Notes

- Do not use `Closes #607`, `Fixes #607`, or `Resolves #607` in this PR unless it actually completes the umbrella issue.
- Prefer wording like `Related to #607`, `Part of #607`, or `Advances #607` for incremental PRs.

