### PR TITLE
Add rhythm pattern override resolution

### DIFF
--- a/drizzle/migrations/sqlite/0021_add_rhythm_pattern_overrides.sql
+++ b/drizzle/migrations/sqlite/0021_add_rhythm_pattern_overrides.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `rhythm_patterns` ADD COLUMN `tune_id` text;
+--> statement-breakpoint
+ALTER TABLE `rhythm_patterns` ADD COLUMN `user_id` text;
+--> statement-breakpoint
+ALTER TABLE `rhythm_patterns` ADD COLUMN `pattern_type` text DEFAULT 'seed' NOT NULL CHECK (`pattern_type` IN ('seed', 'full_track'));

--- a/drizzle/schema-sqlite.generated.ts
+++ b/drizzle/schema-sqlite.generated.ts
@@ -443,6 +443,9 @@ export const rhythmPatterns = sqliteTable("rhythm_patterns", {
   isDefault: integer("is_default").notNull().default(0),
   premiumAudioUrl: text("premium_audio_url"),
   sampleKit: text("sample_kit").notNull().default("bodhran"),
+  tuneId: text("tune_id"),
+  userId: text("user_id"),
+  patternType: text("pattern_type").notNull().default("seed"),
 });
 
 export const setlist = sqliteTable(

--- a/oosync.codegen.config.json
+++ b/oosync.codegen.config.json
@@ -18,8 +18,8 @@
     "dbVersionKeyPrefix": "tunetrees-db-version",
     "outboxBackupKeyPrefix": "tunetrees-outbox-backup",
     "lastSyncTimestampKeyPrefix": "TT_LAST_SYNC_TIMESTAMP",
-    "schemaVersion": "2.0.11-add-rhythm-sample-kit",
-    "databaseVersion": 20,
+    "schemaVersion": "2.0.12-add-rhythm-pattern-overrides",
+    "databaseVersion": 21,
     "migrationDirectory": "drizzle/migrations/sqlite",
     "migrationFiles": [
       "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",
@@ -42,7 +42,8 @@
       "/drizzle/migrations/sqlite/0017_fix_ordered_item_conflict_targets.sql",
       "/drizzle/migrations/sqlite/0018_rename_program_to_setlist.sql",
       "/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql",
-      "/drizzle/migrations/sqlite/0020_add_sample_kit_to_rhythm_patterns.sql"
+      "/drizzle/migrations/sqlite/0020_add_sample_kit_to_rhythm_patterns.sql",
+      "/drizzle/migrations/sqlite/0021_add_rhythm_pattern_overrides.sql"
     ],
     "forceResetQueryParams": [
       { "key": "reset", "value": "true" },

--- a/shared/generated/sync/table-meta.generated.ts
+++ b/shared/generated/sync/table-meta.generated.ts
@@ -401,12 +401,18 @@ export const TABLE_REGISTRY_CORE: Record<SyncableTableName, TableMetaCore> = {
       name: 'A human-readable description for the UI dropdown (e.g., "Basic Rolling", "Driving Backbeat").',
       part_target:
         'Specifies which structural part this pattern targets. "*" or NULL applies to the whole tune, "A" applies only to the A part, "B" to the B part, allowing the groove to change mid-tune.',
+      pattern_type:
+        'Defines how the frontend should render the abc_string. "seed" means tile/repeat it to match the tune length. "full_track" means play it exactly as written without looping.',
       premium_audio_url:
         "Optional URL to a pre-recorded audio loop (e.g., an MP3 hosted on Cloudflare R2). If present, the UI logic should prioritize streaming this file over generating the ABC string.",
       sample_kit:
         'The identifier for the audio sample kit used by the frontend registry (e.g., "bodhran", "spoons") to map MIDI pitches to Cloudflare R2 audio URLs.',
+      tune_id:
+        "If set, this pattern specifically overrides the default for a single tune.",
       tune_type_id:
         "Foreign key component referencing the tune type (e.g., JigD).",
+      user_id:
+        "If set, this pattern is a private override created by a specific user.",
     },
   },
   setlist: {

--- a/shared/table-meta.ts
+++ b/shared/table-meta.ts
@@ -321,12 +321,18 @@ const TABLE_EXTRAS: Record<
       name: 'A human-readable description for the UI dropdown (e.g., "Basic Rolling", "Driving Backbeat").',
       part_target:
         'Specifies which structural part this pattern targets. "*" or NULL applies to the whole tune, "A" applies only to the A part, "B" to the B part, allowing the groove to change mid-tune.',
+      pattern_type:
+        'Defines how the frontend should render the abc_string. "seed" means tile/repeat it to match the tune length. "full_track" means play it exactly as written without looping.',
       premium_audio_url:
         "Optional URL to a pre-recorded audio loop (e.g., an MP3 hosted on Cloudflare R2). If present, the UI logic should prioritize streaming this file over generating the ABC string.",
       sample_kit:
         'The identifier for the audio sample kit used by the frontend registry (e.g., "bodhran", "spoons") to map MIDI pitches to Cloudflare R2 audio URLs.',
+      tune_id:
+        "If set, this pattern specifically overrides the default for a single tune.",
       tune_type_id:
         "Foreign key component referencing the tune type (e.g., JigD).",
+      user_id:
+        "If set, this pattern is a private override created by a specific user.",
     },
   },
   setlist: {

--- a/src/components/rhythm/RhythmPlayer.test.tsx
+++ b/src/components/rhythm/RhythmPlayer.test.tsx
@@ -1,0 +1,199 @@
+import { cleanup, render, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  RhythmPatternMetadata,
+  RhythmService,
+} from "@/lib/services/RhythmService";
+import { RhythmPlayer } from "./RhythmPlayer";
+
+const mocked = vi.hoisted(() => {
+  const renderAbcMock = vi.fn();
+  const loadPatternMock = vi.fn<RhythmService["loadPattern"]>(async () => null);
+  const updateRhythmAbcMock = vi.fn<RhythmService["updateRhythmAbc"]>();
+
+  return {
+    renderAbcMock,
+    loadPatternMock,
+    updateRhythmAbcMock,
+    serviceStub: {
+      metadata: () => null as RhythmPatternMetadata | null,
+      tempoQpm: () => 100,
+      isPlaying: () => false,
+      isReady: () => false,
+      currentBeatIndex: () => 0,
+      currentMeasure: () => 0,
+      error: () => null,
+      loadPattern: loadPatternMock,
+      play: vi.fn(async () => undefined),
+      pause: vi.fn(),
+      restart: vi.fn(async () => undefined),
+      togglePlayback: vi.fn(async () => undefined),
+      setTempoQpm: vi.fn(async () => undefined),
+      updateRhythmAbc: updateRhythmAbcMock,
+    } satisfies RhythmService,
+  };
+});
+
+vi.mock("abcjs", () => ({
+  default: {
+    renderAbc: mocked.renderAbcMock,
+  },
+}));
+
+vi.mock("solid-sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth/AuthContext", () => ({
+  useAuth: () => ({
+    localDb: () => ({ fake: true }),
+    user: () => ({ id: "auth-user-1" }),
+  }),
+}));
+
+vi.mock("@/lib/services/RhythmService", () => ({
+  createRhythmService: () => mocked.serviceStub,
+}));
+
+describe("RhythmPlayer", () => {
+  beforeEach(() => {
+    mocked.renderAbcMock.mockReset();
+    mocked.renderAbcMock.mockReturnValue([]);
+    mocked.loadPatternMock.mockReset();
+    mocked.loadPatternMock.mockResolvedValue(null);
+    mocked.updateRhythmAbcMock.mockReset();
+    mocked.serviceStub.metadata = () => null;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("passes tuneId and current auth userId into loadPattern", async () => {
+    render(() => (
+      <RhythmPlayer
+        tuneTypeName="Reel"
+        genreName="Irish Traditional"
+        tuneId="tune-42"
+      />
+    ));
+
+    await waitFor(() => {
+      expect(mocked.loadPatternMock).toHaveBeenCalledWith({
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        tuneId: "tune-42",
+        userId: "auth-user-1",
+      });
+    });
+  });
+
+  it("expands seed patterns to the requested structure before playback/rendering", async () => {
+    const seedAbc = [
+      "X:1",
+      "T:Seed Pattern",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      "|: C2 A2 C2 A2 :|",
+    ].join("\n");
+
+    mocked.loadPatternMock.mockImplementation(async () => {
+      return {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        rhythmAbc: seedAbc,
+        rhythmSignature: "4/4",
+        patternType: "seed",
+        tempoQpm: 112,
+        sampleKit: "bodhran",
+        premiumAudioUrl: null,
+        premiumAudioTrimMs: 0,
+        premiumAudioSource: null,
+        premiumAudioSourceTempoQpm: null,
+        source: "rhythm_patterns",
+      };
+    });
+    mocked.serviceStub.metadata = () => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: seedAbc,
+      rhythmSignature: "4/4",
+      patternType: "seed" as const,
+      tempoQpm: 112,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+    });
+
+    render(() => <RhythmPlayer tuneTypeName="Reel" structure="A2 B2" />);
+
+    await waitFor(() => {
+      expect(mocked.updateRhythmAbcMock).toHaveBeenCalled();
+    });
+
+    const expandedAbc = mocked.updateRhythmAbcMock.mock.calls.at(
+      -1
+    )?.[0] as string;
+    expect(expandedAbc).toContain(
+      "| C2 A2 C2 A2 | C2 A2 C2 A2 | C2 A2 C2 A2 | C2 A2 C2 A2 |"
+    );
+  });
+
+  it("keeps full_track patterns exactly as written", async () => {
+    const fullTrackAbc = [
+      "X:1",
+      "T:Full Track",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      "| C2 A2 C2 A2 | D2 A2 D2 A2 |",
+    ].join("\n");
+
+    mocked.loadPatternMock.mockImplementation(async () => {
+      return {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        rhythmAbc: fullTrackAbc,
+        rhythmSignature: "4/4",
+        patternType: "full_track",
+        tempoQpm: 112,
+        sampleKit: "bodhran",
+        premiumAudioUrl: null,
+        premiumAudioTrimMs: 0,
+        premiumAudioSource: null,
+        premiumAudioSourceTempoQpm: null,
+        source: "rhythm_patterns",
+      };
+    });
+    mocked.serviceStub.metadata = () => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: fullTrackAbc,
+      rhythmSignature: "4/4",
+      patternType: "full_track" as const,
+      tempoQpm: 112,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+    });
+
+    render(() => <RhythmPlayer tuneTypeName="Reel" structure="A2 B2" />);
+
+    await waitFor(() => {
+      expect(mocked.updateRhythmAbcMock).toHaveBeenCalled();
+    });
+
+    expect(mocked.updateRhythmAbcMock.mock.calls.at(-1)?.[0]).toBe(
+      fullTrackAbc
+    );
+  });
+});

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -12,6 +12,7 @@ import {
 } from "solid-js";
 import { toast } from "solid-sonner";
 import { useAuth } from "@/lib/auth/AuthContext";
+import type { RhythmPatternType } from "@/lib/services/RhythmService";
 import { createRhythmService } from "@/lib/services/RhythmService";
 import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -19,6 +20,7 @@ import "./rhythm-player.css";
 
 export interface RhythmPlayerProps {
   tuneTypeName: string | null;
+  tuneId?: string | null;
   structure?: string | null;
   genreName?: string | null;
   class?: string;
@@ -151,13 +153,51 @@ function beatsPerMeasureFromSignature(rhythmSignature?: string | null): number {
   return Number.isFinite(numerator) && numerator > 0 ? numerator : 4;
 }
 
-function expandRhythmAbc(
+function normalizeAbcBodyBars(abcBody: string): string[] {
+  return abcBody
+    .replace(/^\s*\|:/, "")
+    .replace(/:\|\s*$/, "")
+    .split("|")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function expandSeedRhythmAbc(abc: string, structuredBarCount: number): string {
+  if (structuredBarCount <= 0) {
+    return abc;
+  }
+
+  const lines = abc
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean);
+  const headerLines = lines.filter((line) => /^[A-Z]:/.test(line));
+  const bodyLines = lines.filter((line) => !/^[A-Z]:/.test(line));
+  const bodyBars = normalizeAbcBodyBars(bodyLines.join(" "));
+
+  if (bodyBars.length === 0 || structuredBarCount <= bodyBars.length) {
+    return abc;
+  }
+
+  const expandedBars = Array.from(
+    { length: structuredBarCount },
+    (_value, index) => bodyBars[index % bodyBars.length]
+  );
+
+  return [...headerLines, `| ${expandedBars.join(" | ")} |`].join("\n");
+}
+
+function expandRhythmAbcByPatternType(
   abc: string,
-  _structuredBarCount: number,
-  _defaultBarsPerPattern = 4,
-  _structure?: string | null
+  patternType: RhythmPatternType,
+  structuredBarCount: number,
+  structure?: string | null
 ): string {
-  return abc;
+  if (patternType === "full_track" || !normalizeStructure(structure)) {
+    return abc;
+  }
+
+  return expandSeedRhythmAbc(abc, structuredBarCount);
 }
 
 function getBeatNoteTargets(container: HTMLDivElement): SVGElement[] {
@@ -212,7 +252,7 @@ function convertRhythmAbcForDisplay(abc: string): string {
 }
 
 export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
-  const { localDb } = useAuth();
+  const { localDb, user } = useAuth();
   let activeBeatTargets: ActiveBeatTarget[] = [];
   let lastToastError: string | null = null;
 
@@ -249,13 +289,20 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
    */
   const expandedAbc = createMemo(() => {
     const abc = metadata()?.rhythmAbc;
+    const patternType = metadata()?.patternType ?? "seed";
     const structure = effectiveStructure();
     if (!abc) return null;
+    if (!structure) return abc;
 
     const structuredBarCount = parseStructureTotalBars(structure);
     if (structuredBarCount <= 0) return abc;
 
-    return expandRhythmAbc(abc, structuredBarCount, 4, structure);
+    return expandRhythmAbcByPatternType(
+      abc,
+      patternType,
+      structuredBarCount,
+      structure
+    );
   });
 
   const displayAbc = createMemo(() => {
@@ -337,6 +384,8 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
       .loadPattern({
         genreName: props.genreName?.trim() || null,
         tuneTypeName,
+        tuneId: props.tuneId?.trim() || null,
+        userId: user()?.id ?? null,
       })
       .finally(() => {
         setIsPatternLoading(false);

--- a/src/lib/db/client-sqlite.ts
+++ b/src/lib/db/client-sqlite.ts
@@ -38,8 +38,8 @@ export const browserSqliteClient = createBrowserSqliteClient({
     outboxBackupKeyPrefix: "tunetrees-outbox-backup",
     lastSyncTimestampKeyPrefix: "TT_LAST_SYNC_TIMESTAMP",
   },
-  databaseVersion: 20,
-  schemaVersion: "2.0.11-add-rhythm-sample-kit",
+  databaseVersion: 21,
+  schemaVersion: "2.0.12-add-rhythm-pattern-overrides",
   migrationFiles: [
     "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",
     "/drizzle/migrations/sqlite/0001_thin_chronomancer.sql",
@@ -62,6 +62,7 @@ export const browserSqliteClient = createBrowserSqliteClient({
     "/drizzle/migrations/sqlite/0018_rename_program_to_setlist.sql",
     "/drizzle/migrations/sqlite/0019_add_rhythm_patterns_and_default_bpm.sql",
     "/drizzle/migrations/sqlite/0020_add_sample_kit_to_rhythm_patterns.sql",
+    "/drizzle/migrations/sqlite/0021_add_rhythm_pattern_overrides.sql",
   ],
   forceResetQueryParams: [
     { key: "reset", value: "true" },

--- a/src/lib/services/RhythmService.test.ts
+++ b/src/lib/services/RhythmService.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import Database from "better-sqlite3";
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -8,6 +10,8 @@ import {
   createRhythmService,
   loadRhythmPatternMetadata,
 } from "./RhythmService";
+
+const projectRoot = path.resolve(__dirname, "..", "..", "..");
 
 function createDb(sqlStatements: string[]): SqliteDatabase {
   const sqlite = new Database(":memory:");
@@ -25,17 +29,17 @@ function createPremiumLoopRhythmDb() {
     "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
     "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
     "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
-    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran')",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran', tune_id TEXT, user_id TEXT, pattern_type TEXT NOT NULL DEFAULT 'seed')",
     "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
     "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
     "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
-    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit)
+    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit, tune_id, user_id, pattern_type)
       VALUES ('rp-1', 'ITRAD', 'Reel', 'Basic Rolling', '*', 'X:1
 T:Reel Groove
 M:4/4
 L:1/8
 K:clef=perc
-|: C2 A2 C2 A2 :|', 1, NULL, 'bodhran')`,
+|: C2 A2 C2 A2 :|', 1, NULL, 'bodhran', NULL, NULL, 'seed')`,
   ]);
 }
 
@@ -44,17 +48,17 @@ function createSampleKitRhythmDb() {
     "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
     "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
     "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
-    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran')",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran', tune_id TEXT, user_id TEXT, pattern_type TEXT NOT NULL DEFAULT 'seed')",
     "INSERT INTO genre (id, name) VALUES ('TEST', 'Session Test')",
     "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
     "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('TEST', 'Reel', 112)",
-    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit)
+    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit, tune_id, user_id, pattern_type)
       VALUES ('rp-1', 'TEST', 'Reel', 'Basic Rolling', '*', 'X:1
 T:Reel Groove
 M:4/4
 L:1/8
 K:clef=perc
-|: C2 A2 C2 A2 :|', 1, NULL, 'bodhran')`,
+|: C2 A2 C2 A2 :|', 1, NULL, 'bodhran', NULL, NULL, 'seed')`,
   ]);
 }
 
@@ -92,11 +96,91 @@ function createRhythmDbWithoutPatternRow() {
     "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
     "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
     "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
-    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran')",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran', tune_id TEXT, user_id TEXT, pattern_type TEXT NOT NULL DEFAULT 'seed')",
     "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
     "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
     "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
   ]);
+}
+
+function createHierarchicalRhythmDb(options?: {
+  includeUserTuneOverride?: boolean;
+  includeGlobalTuneOverride?: boolean;
+  includeUserDefault?: boolean;
+}) {
+  const {
+    includeUserTuneOverride = true,
+    includeGlobalTuneOverride = true,
+    includeUserDefault = true,
+  } = options ?? {};
+
+  const statements = [
+    "CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)",
+    "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)",
+    "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, default_bpm INTEGER, PRIMARY KEY (genre_id, tune_type_id))",
+    "CREATE TABLE rhythm_patterns (id TEXT PRIMARY KEY, genre_id TEXT, tune_type_id TEXT NOT NULL, name TEXT NOT NULL, part_target TEXT DEFAULT '*', abc_string TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, premium_audio_url TEXT, sample_kit TEXT NOT NULL DEFAULT 'bodhran', tune_id TEXT, user_id TEXT, pattern_type TEXT NOT NULL DEFAULT 'seed')",
+    "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')",
+    "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')",
+    "INSERT INTO genre_tune_type (genre_id, tune_type_id, default_bpm) VALUES ('ITRAD', 'Reel', 112)",
+    `INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit, tune_id, user_id, pattern_type)
+      VALUES ('system-default', 'ITRAD', 'Reel', 'System Default', '*', 'X:1
+T:System Default
+M:4/4
+L:1/8
+K:clef=perc
+|: C2 A2 C2 A2 :|', 1, NULL, 'bodhran', NULL, NULL, 'seed')`,
+  ];
+
+  if (includeUserDefault) {
+    statements.push(`INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit, tune_id, user_id, pattern_type)
+      VALUES ('user-default', 'ITRAD', 'Reel', 'User Default', '*', 'X:1
+T:User Default
+M:4/4
+L:1/8
+K:clef=perc
+|: D2 A2 D2 A2 :|', 0, NULL, 'generic_click', NULL, 'user-1', 'seed')`);
+  }
+
+  if (includeGlobalTuneOverride) {
+    statements.push(`INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit, tune_id, user_id, pattern_type)
+      VALUES ('global-tune', 'ITRAD', 'Reel', 'Global Tune Override', '*', 'X:1
+T:Global Tune Override
+M:4/4
+L:1/8
+K:clef=perc
+|: E2 A2 E2 A2 :|', 0, NULL, 'bodhran', 'tune-1', NULL, 'full_track')`);
+  }
+
+  if (includeUserTuneOverride) {
+    statements.push(`INSERT INTO rhythm_patterns (id, genre_id, tune_type_id, name, part_target, abc_string, is_default, premium_audio_url, sample_kit, tune_id, user_id, pattern_type)
+      VALUES ('user-tune', 'ITRAD', 'Reel', 'User Tune Override', '*', 'X:1
+T:User Tune Override
+M:4/4
+L:1/8
+K:clef=perc
+|: F2 A2 F2 A2 :|', 0, 'custom/user-tune.mp3', 'bodhran', 'tune-1', 'user-1', 'full_track')`);
+  }
+
+  return createDb(statements);
+}
+
+function applySqliteMigration(db: Database.Database, fileName: string) {
+  const migrationPath = path.join(
+    projectRoot,
+    "drizzle",
+    "migrations",
+    "sqlite",
+    fileName
+  );
+  const contents = fs.readFileSync(migrationPath, "utf8");
+  const statements = contents
+    .split(/-->\s*statement-breakpoint/g)
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+
+  for (const statement of statements) {
+    db.exec(statement);
+  }
 }
 
 function createRhythmDbWithLegacyPatternColumns() {
@@ -133,6 +217,7 @@ describe("loadRhythmPatternMetadata", () => {
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Reel",
+      patternType: "seed",
       tempoQpm: 112,
       sampleKit: "bodhran",
       premiumAudioSource: "registry",
@@ -162,6 +247,7 @@ describe("loadRhythmPatternMetadata", () => {
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Reel",
+      patternType: "seed",
       tempoQpm: 112,
       sampleKit: "generic_click",
       premiumAudioSource: "registry",
@@ -191,6 +277,7 @@ describe("loadRhythmPatternMetadata", () => {
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Reel",
+      patternType: "seed",
       tempoQpm: 112,
       sampleKit: "generic_click",
       premiumAudioSource: "registry",
@@ -220,6 +307,7 @@ describe("loadRhythmPatternMetadata", () => {
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Jig",
+      patternType: "seed",
       tempoQpm: 115,
       sampleKit: "generic_click",
       premiumAudioSource: "registry",
@@ -248,6 +336,7 @@ describe("loadRhythmPatternMetadata", () => {
     expect(metadata).toMatchObject({
       genreName: "Irish Traditional",
       tuneTypeName: "Polka",
+      patternType: "seed",
       tempoQpm: 120,
       sampleKit: "generic_click",
       premiumAudioSource: "registry",
@@ -294,11 +383,183 @@ describe("loadRhythmPatternMetadata", () => {
     expect(metadata).toMatchObject({
       genreName: null,
       tuneTypeName: "Reel",
+      patternType: "seed",
       tempoQpm: 100,
       source: "tune_type_fallback",
     });
     expect(metadata?.rhythmAbc).toContain("M:4/4");
     expect(metadata?.rhythmAbc).toContain("K:clef=perc");
+  });
+  it("prioritizes the user tune override over tune and user defaults", async () => {
+    const db = createHierarchicalRhythmDb();
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        tuneId: "tune-1",
+        userId: "user-1",
+      },
+      {
+        sampleBaseUrl: "https://media.example.test",
+      }
+    );
+
+    expect(metadata).toMatchObject({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      patternType: "full_track",
+      sampleKit: "bodhran",
+      premiumAudioSource: "database",
+      source: "rhythm_patterns",
+    });
+    expect(metadata?.rhythmAbc).toContain("User Tune Override");
+    expect(metadata?.premiumAudioUrl).toBe(
+      "https://media.example.test/custom/user-tune.mp3"
+    );
+  });
+
+  it("prioritizes the global tune override before the user default", async () => {
+    const db = createHierarchicalRhythmDb({
+      includeUserTuneOverride: false,
+    });
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        tuneId: "tune-1",
+        userId: "user-1",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
+
+    expect(metadata).toMatchObject({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      patternType: "full_track",
+      sampleKit: "bodhran",
+      source: "rhythm_patterns",
+    });
+    expect(metadata?.rhythmAbc).toContain("Global Tune Override");
+  });
+
+  it("prioritizes the user default before the system default when no tune override exists", async () => {
+    const db = createHierarchicalRhythmDb({
+      includeUserTuneOverride: false,
+      includeGlobalTuneOverride: false,
+    });
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        userId: "user-1",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
+
+    expect(metadata).toMatchObject({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      patternType: "seed",
+      sampleKit: "generic_click",
+      source: "rhythm_patterns",
+    });
+    expect(metadata?.rhythmAbc).toContain("User Default");
+  });
+});
+
+describe("rhythm pattern sqlite migrations", () => {
+  it("adds sample_kit, tune_id, user_id, and pattern_type to migrated local sqlite databases", () => {
+    const sqlite = new Database(":memory:");
+
+    sqlite.exec("CREATE TABLE genre (id TEXT PRIMARY KEY, name TEXT)");
+    sqlite.exec(
+      "CREATE TABLE tune_type (id TEXT PRIMARY KEY, name TEXT, rhythm TEXT, description TEXT)"
+    );
+    sqlite.exec(
+      "CREATE TABLE genre_tune_type (genre_id TEXT NOT NULL, tune_type_id TEXT NOT NULL, PRIMARY KEY (genre_id, tune_type_id))"
+    );
+    sqlite.exec(
+      "INSERT INTO genre (id, name) VALUES ('ITRAD', 'Irish Traditional')"
+    );
+    sqlite.exec(
+      "INSERT INTO tune_type (id, name, rhythm, description) VALUES ('Reel', 'Reel', '4/4', 'Reel rhythm')"
+    );
+
+    applySqliteMigration(
+      sqlite,
+      "0019_add_rhythm_patterns_and_default_bpm.sql"
+    );
+    applySqliteMigration(sqlite, "0020_add_sample_kit_to_rhythm_patterns.sql");
+    applySqliteMigration(sqlite, "0021_add_rhythm_pattern_overrides.sql");
+
+    const columns = sqlite
+      .prepare("PRAGMA table_info(rhythm_patterns)")
+      .all() as Array<{
+      name: string;
+      notnull: number;
+      dflt_value: string | null;
+    }>;
+
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "sample_kit",
+        "tune_id",
+        "user_id",
+        "pattern_type",
+      ])
+    );
+
+    const patternTypeColumn = columns.find(
+      (column) => column.name === "pattern_type"
+    );
+    expect(patternTypeColumn?.notnull).toBe(1);
+    expect(patternTypeColumn?.dflt_value ?? "").toContain("seed");
+
+    sqlite.exec(`INSERT INTO rhythm_patterns (
+      id,
+      genre_id,
+      tune_type_id,
+      name,
+      abc_string,
+      is_default
+    ) VALUES (
+      'migrated-row',
+      'ITRAD',
+      'Reel',
+      'Migrated Row',
+      'X:1\nT:Migrated\nM:4/4\nL:1/8\nK:clef=perc\n|: C2 A2 C2 A2 :|',
+      1
+    )`);
+
+    const row = sqlite
+      .prepare(
+        "SELECT sample_kit, tune_id, user_id, pattern_type FROM rhythm_patterns WHERE id = 'migrated-row'"
+      )
+      .get() as {
+      sample_kit: string;
+      tune_id: string | null;
+      user_id: string | null;
+      pattern_type: string;
+    };
+
+    expect(row).toMatchObject({
+      sample_kit: "bodhran",
+      tune_id: null,
+      user_id: null,
+      pattern_type: "seed",
+    });
+
+    sqlite.close();
   });
 });
 

--- a/src/lib/services/RhythmService.ts
+++ b/src/lib/services/RhythmService.ts
@@ -149,7 +149,11 @@ const DEFAULT_TEMPO_BY_TYPE: Record<string, number> = {
 export interface RhythmPatternRequest {
   genreName?: string | null;
   tuneTypeName?: string | null;
+  tuneId?: string | null;
+  userId?: string | null;
 }
+
+export type RhythmPatternType = "seed" | "full_track";
 
 export interface RhythmPatternMetadata {
   genreName: string | null;
@@ -157,6 +161,7 @@ export interface RhythmPatternMetadata {
   rhythmAbc: string;
   rhythmSignature: string | null;
   tuneStructure?: string | null;
+  patternType: RhythmPatternType;
   tempoQpm: number;
   sampleKit: string;
   premiumAudioUrl: string | null;
@@ -244,6 +249,10 @@ function getDefaultTempoForTuneType(tuneTypeName: string): number {
 
 function normalizeSampleKit(sampleKit?: string | null): string {
   return sampleKit?.trim() || DEFAULT_SAMPLE_KIT;
+}
+
+function normalizePatternType(patternType?: string | null): RhythmPatternType {
+  return patternType === "full_track" ? "full_track" : "seed";
 }
 
 function getSampleKitMapping(
@@ -420,9 +429,15 @@ export async function loadRhythmPatternMetadata(
   const hasSampleKitColumn = rhythmPatternColumns.has("sample_kit");
   const hasPremiumAudioUrlColumn =
     rhythmPatternColumns.has("premium_audio_url");
+  const hasTuneIdColumn = rhythmPatternColumns.has("tune_id");
+  const hasUserIdColumn = rhythmPatternColumns.has("user_id");
+  const hasPatternTypeColumn = rhythmPatternColumns.has("pattern_type");
+  const canUseHierarchicalOverrides = hasTuneIdColumn && hasUserIdColumn;
   const sampleBaseUrl = options?.sampleBaseUrl ?? DEFAULT_SAMPLE_BASE_URL;
 
   const genreFilter = request.genreName?.trim() || null;
+  const tuneIdFilter = request.tuneId?.trim() || null;
+  const userIdFilter = request.userId?.trim() || null;
 
   if (canUseRhythmPatterns) {
     const rows = await db.all<{
@@ -433,6 +448,7 @@ export async function loadRhythmPatternMetadata(
       abc_string: string | null;
       sample_kit: string | null;
       premium_audio_url: string | null;
+      pattern_type: string | null;
     }>(sql`
       WITH tune_type_match AS (
         SELECT id, name, rhythm
@@ -460,10 +476,39 @@ export async function loadRhythmPatternMetadata(
               ? sql`rp.premium_audio_url`
               : sql`CAST(NULL AS TEXT)`
           } AS premium_audio_url,
+          ${
+            hasPatternTypeColumn
+              ? sql`rp.pattern_type`
+              : sql`CAST('seed' AS TEXT)`
+          } AS pattern_type,
           rp.is_default,
           rp.part_target,
           ROW_NUMBER() OVER (
             ORDER BY
+              ${
+                canUseHierarchicalOverrides
+                  ? sql`
+                    CASE
+                      WHEN ${userIdFilter} IS NOT NULL
+                       AND ${tuneIdFilter} IS NOT NULL
+                       AND rp.user_id = ${userIdFilter}
+                       AND rp.tune_id = ${tuneIdFilter} THEN 0
+                      WHEN ${tuneIdFilter} IS NOT NULL
+                       AND rp.user_id IS NULL
+                       AND rp.tune_id = ${tuneIdFilter} THEN 1
+                      WHEN ${userIdFilter} IS NOT NULL
+                       AND rp.user_id = ${userIdFilter}
+                       AND rp.tune_id IS NULL THEN 2
+                      WHEN rp.user_id IS NULL
+                       AND rp.tune_id IS NULL
+                       AND rp.is_default THEN 3
+                      WHEN rp.user_id IS NULL
+                       AND rp.tune_id IS NULL THEN 4
+                      ELSE 5
+                    END,
+                  `
+                  : sql``
+              }
               CASE WHEN rp.is_default THEN 0 ELSE 1 END,
               CASE
                 WHEN rp.part_target IS NULL OR rp.part_target = '*' THEN 0
@@ -475,6 +520,25 @@ export async function loadRhythmPatternMetadata(
         JOIN tune_type_match ttm ON rp.tune_type_id = ttm.id
         LEFT JOIN genre_match gm ON 1 = 1
         WHERE (gm.id IS NULL OR rp.genre_id = gm.id)
+          AND ${
+            canUseHierarchicalOverrides
+              ? sql`
+                (
+                  (${userIdFilter} IS NOT NULL
+                    AND ${tuneIdFilter} IS NOT NULL
+                    AND rp.user_id = ${userIdFilter}
+                    AND rp.tune_id = ${tuneIdFilter})
+                  OR (${tuneIdFilter} IS NOT NULL
+                    AND rp.user_id IS NULL
+                    AND rp.tune_id = ${tuneIdFilter})
+                  OR (${userIdFilter} IS NOT NULL
+                    AND rp.user_id = ${userIdFilter}
+                    AND rp.tune_id IS NULL)
+                  OR (rp.user_id IS NULL AND rp.tune_id IS NULL)
+                )
+              `
+              : sql`1 = 1`
+          }
       )
       SELECT
         gm.name AS genre_name,
@@ -487,7 +551,8 @@ export async function loadRhythmPatternMetadata(
         } AS tempo_qpm,
         sp.abc_string AS abc_string,
         sp.sample_kit AS sample_kit,
-        sp.premium_audio_url AS premium_audio_url
+        sp.premium_audio_url AS premium_audio_url,
+        sp.pattern_type AS pattern_type
       FROM tune_type_match ttm
       LEFT JOIN genre_match gm ON 1 = 1
       LEFT JOIN genre_tune_type gtt
@@ -515,6 +580,7 @@ export async function loadRhythmPatternMetadata(
         tuneTypeName: row.tune_type_name,
         rhythmSignature: row.rhythm_signature ?? null,
         rhythmAbc: row.abc_string.trim(),
+        patternType: normalizePatternType(row.pattern_type),
         tempoQpm: resolvedTempoQpm,
         sampleKit: normalizeSampleKit(row.sample_kit),
         premiumAudioUrl: premiumLoop?.url ?? null,
@@ -579,6 +645,7 @@ export async function loadRhythmPatternMetadata(
           row.tune_type_name,
           row.rhythm_signature ?? null
         ),
+        patternType: "seed",
         tempoQpm: resolvedTempoQpm,
         sampleKit: DEFAULT_SAMPLE_KIT,
         premiumAudioUrl: premiumLoop?.url ?? null,
@@ -613,6 +680,7 @@ export async function loadRhythmPatternMetadata(
       fallbackRow.tune_type_name,
       fallbackRow.rhythm_signature ?? null
     ),
+    patternType: "seed",
     tempoQpm: getDefaultTempoForTuneType(fallbackRow.tune_type_name),
     sampleKit: DEFAULT_SAMPLE_KIT,
     premiumAudioUrl: null,

--- a/supabase/migrations/20260513000000_add_rhythm_pattern_overrides.sql
+++ b/supabase/migrations/20260513000000_add_rhythm_pattern_overrides.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE public.rhythm_patterns
+ADD COLUMN tune_id UUID NULL,
+ADD COLUMN user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NULL,
+ADD COLUMN pattern_type TEXT NOT NULL DEFAULT 'seed' CHECK (pattern_type IN ('seed', 'full_track'));
+
+COMMENT ON COLUMN public.rhythm_patterns.tune_id IS 'If set, this pattern specifically overrides the default for a single tune.';
+COMMENT ON COLUMN public.rhythm_patterns.user_id IS 'If set, this pattern is a private override created by a specific user.';
+COMMENT ON COLUMN public.rhythm_patterns.pattern_type IS 'Defines how the frontend should render the abc_string. "seed" means tile/repeat it to match the tune length. "full_track" means play it exactly as written without looping.';
+
+COMMIT;

--- a/supabase/migrations/20260513000000_add_rhythm_pattern_overrides.sql
+++ b/supabase/migrations/20260513000000_add_rhythm_pattern_overrides.sql
@@ -5,6 +5,13 @@ ADD COLUMN tune_id UUID NULL,
 ADD COLUMN user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NULL,
 ADD COLUMN pattern_type TEXT NOT NULL DEFAULT 'seed' CHECK (pattern_type IN ('seed', 'full_track'));
 
+DROP POLICY IF EXISTS "Anyone can view rhythm_patterns" ON public.rhythm_patterns;
+
+CREATE POLICY "Anyone can view rhythm_patterns"
+ON public.rhythm_patterns
+FOR SELECT
+USING (user_id IS NULL OR user_id = auth.uid());
+
 COMMENT ON COLUMN public.rhythm_patterns.tune_id IS 'If set, this pattern specifically overrides the default for a single tune.';
 COMMENT ON COLUMN public.rhythm_patterns.user_id IS 'If set, this pattern is a private override created by a specific user.';
 COMMENT ON COLUMN public.rhythm_patterns.pattern_type IS 'Defines how the frontend should render the abc_string. "seed" means tile/repeat it to match the tune length. "full_track" means play it exactly as written without looping.';

--- a/worker/src/generated/schema-postgres.generated.ts
+++ b/worker/src/generated/schema-postgres.generated.ts
@@ -331,6 +331,9 @@ export const rhythmPatterns = pgTable("rhythm_patterns", {
   isDefault: boolean("is_default").notNull().default(false),
   premiumAudioUrl: text("premium_audio_url"),
   sampleKit: text("sample_kit").notNull().default("bodhran"),
+  tuneId: uuid("tune_id"),
+  userId: uuid("user_id"),
+  patternType: text("pattern_type").notNull().default("seed"),
 });
 
 export const setlist = pgTable("setlist", {

--- a/worker/src/generated/worker-config.generated.ts
+++ b/worker/src/generated/worker-config.generated.ts
@@ -62,6 +62,11 @@ export const WORKER_SYNC_CONFIG = {
       idColumn: "repertoire_id",
       ownerColumn: "user_ref",
     },
+    rhythmPatternsIds: {
+      table: "rhythm_patterns",
+      idColumn: "id",
+      ownerColumn: "user_id",
+    },
     setlistIds: {
       table: "setlist",
       idColumn: "id",
@@ -236,6 +241,10 @@ export const WORKER_SYNC_CONFIG = {
         kind: "inCollection",
         column: "repertoire_ref",
         collection: "repertoireIds",
+      },
+      rhythm_patterns: {
+        kind: "orNullEqUserId",
+        column: "user_id",
       },
       setlist: {
         kind: "rpc",


### PR DESCRIPTION
## Summary

This PR delivers one mergeable slice of #607.

Related to #607.

Note: this PR advances #607 but does not close it.

## Advances #607

- Adds `tune_id`, `user_id`, and `pattern_type` to `rhythm_patterns`, updates generated schema/runtime artifacts, and adds the matching SQLite WASM migration path.
- Implements hierarchical rhythm pattern resolution in `RhythmService` and adds focused tests for override precedence, migration coverage, and `seed` vs `full_track` component behavior.

## Not in this PR

- Mounting `RhythmPlayer` into the live phase-3 UI flow or wiring the tune-type badge/dialog launch path.
- Rich full-track rendering/playback semantics beyond the current component-level `seed` expansion vs `full_track` passthrough behavior.

## Merge safety

This is safe to merge now because:
- The schema change is additive, backward-compatible for existing defaults, and includes both Supabase and local SQLite migration coverage.
- Validation passed across lint, check, typecheck, unit tests, and a focused `RhythmPlayer` component test.

## Review focus

- The `RhythmService` query ordering and filtering for user+tune, tune, user default, and system default precedence.
- The SQLite/browser migration version bump and the `RhythmPlayer` `patternType` handling for `seed` expansion versus `full_track` passthrough.

## Validation

- `npm run lint && npm run check && npm run typecheck && npm run test:unit`
- `npx vitest run src/components/rhythm/RhythmPlayer.test.tsx`

## Notes

- Do not use `Closes #607`, `Fixes #607`, or `Resolves #607` in this PR unless it actually completes the umbrella issue.
- Prefer wording like `Related to #607`, `Part of #607`, or `Advances #607` for incremental PRs.