### PR TITLE
 🐛  ✅  Fix section wrapping bug,  add test test for same

### DIFF
--- a/src/components/rhythm/RhythmPlayer.test.tsx
+++ b/src/components/rhythm/RhythmPlayer.test.tsx
@@ -219,6 +219,26 @@ describe("RhythmPlayer", () => {
     expect(getStructuredSectionLabel(sourceAbc, "AABB", 25)).toBe("B2");
   });
 
+  it("wraps AABB section passes after a later-section playback start", () => {
+    const sourceAbc = [
+      "X:1",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      `| ${[
+        ...Array.from({ length: 8 }, () => "A2"),
+        ...Array.from({ length: 8 }, () => "a2"),
+        ...Array.from({ length: 8 }, () => "B2"),
+        ...Array.from({ length: 8 }, () => "b2"),
+      ].join(" | ")} |`,
+    ].join("\n");
+
+    expect(getStructuredSectionLabel(sourceAbc, "AABB", 33)).toBe("A");
+    expect(getStructuredSectionLabel(sourceAbc, "AABB", 41)).toBe("A2");
+    expect(getStructuredSectionLabel(sourceAbc, "AABB", 49)).toBe("B");
+    expect(getStructuredSectionLabel(sourceAbc, "AABB", 57)).toBe("B2");
+  });
+
   it("rewrites the rendered svg part labels for the active repeat pass", () => {
     const container = document.createElement("div");
     const makePartLabel = (lineIndex: number, label: string) => {
@@ -565,6 +585,62 @@ describe("RhythmPlayer", () => {
       expect(
         view.getByTestId("rhythm-player-current-section-badge").textContent
       ).toContain("A2");
+    });
+  });
+
+  it("wraps the current section badge correctly after starting from a later AABB section", async () => {
+    const seedAbc = [
+      "X:1",
+      "T:Seed Pattern",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      `| ${[
+        ...Array.from({ length: 8 }, () => "A2"),
+        ...Array.from({ length: 8 }, () => "a2"),
+        ...Array.from({ length: 8 }, () => "B2"),
+        ...Array.from({ length: 8 }, () => "b2"),
+      ].join(" | ")} |`,
+    ].join("\n");
+
+    mocked.loadPatternMock.mockResolvedValue({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: seedAbc,
+      rhythmSignature: "4/4",
+      patternType: "seed",
+      tempoQpm: 115,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns",
+    });
+    mocked.serviceStub.metadata = () => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: seedAbc,
+      rhythmSignature: "4/4",
+      patternType: "seed" as const,
+      tempoQpm: 115,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+    });
+    mocked.serviceStub.currentBeatIndex = () => 33;
+
+    const view = render(() => (
+      <RhythmPlayer tuneTypeName="Reel" structure="AABB" />
+    ));
+
+    await waitFor(() => {
+      expect(
+        view.getByTestId("rhythm-player-current-section-badge").textContent
+      ).toContain("A");
     });
   });
 

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -479,7 +479,15 @@ function getStructuredPlaybackPosition(
       sectionBars.reduce((sum, bar) => sum + countBarEvents(bar), 0)
   );
 
-  let remainingBeatIndex = currentBeatIndex - 1;
+  const totalEventCount = partEventCounts.reduce(
+    (sum, eventCount) => sum + eventCount,
+    0
+  );
+  if (totalEventCount <= 0) {
+    return null;
+  }
+
+  let remainingBeatIndex = (currentBeatIndex - 1) % totalEventCount;
   let activePartIndex = -1;
   for (let index = 0; index < partEventCounts.length; index += 1) {
     const eventCount = partEventCounts[index] ?? 0;


### PR DESCRIPTION
## Summary

Fixed the local wraparound bug in RhythmPlayer.tsx that was causing structured section mapping to fall off the end of the form once playback started from a later section and the beat index passed the total event count. The helper now wraps `currentBeatIndex` modulo the structured form length instead of returning no active section after the first pass.

Added two regressions in RhythmPlayer.test.tsx: one at the helper level for wrapped AABB section labels, and one user-facing check that the current section badge still reports `A` correctly after a later-section start has advanced past the end of the original form.

This PR fixes #625.

Related to #607.

## Validation

- `npm run lint && npm run check && npm run typecheck && npm run test:unit`
- RhythmPlayer.test.tsx passed with 23 tests
