### PR TITLE
Rhythm accomp pat select i635

### DIFF
--- a/e2e/tests/practice-005-date-rollover-banner.spec.ts
+++ b/e2e/tests/practice-005-date-rollover-banner.spec.ts
@@ -96,6 +96,12 @@ async function resetLocalDbAndReopenPractice(page: Page, userId: string) {
 }
 
 async function getQueueRows(page: Page, repertoireId: string) {
+  // Ensure the test API is actually available before attempting to query.
+  // After resetLocalDbAndReopenPractice the app may redirect asynchronously
+  // (e.g. auth drift during sync), leaving the page on e2e-origin.html where
+  // __ttTestApi does not exist.
+  await waitForTestApi(page);
+
   return await page.evaluate(async (rid) => {
     const api = (window as any).__ttTestApi;
     if (!api || typeof api.getPracticeQueue !== "function") {

--- a/src/components/rhythm/RhythmPlayer.test.tsx
+++ b/src/components/rhythm/RhythmPlayer.test.tsx
@@ -654,6 +654,105 @@ describe("RhythmPlayer", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("shows a pattern selector when multiple pattern candidates are available", async () => {
+    const defaultAbc = [
+      "X:1",
+      "T:System Default",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      "|: C2 A2 C2 A2 :|",
+    ].join("\n");
+    const userAbc = [
+      "X:1",
+      "T:User Default",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      "|: D2 A2 D2 A2 :|",
+    ].join("\n");
+
+    let currentMetadata = {
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: defaultAbc,
+      rhythmSignature: "4/4",
+      patternType: "seed" as const,
+      tempoQpm: 112,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+      selectedPatternId: "system-default",
+      patternCandidates: [
+        {
+          id: "system-default",
+          name: "System Default",
+          scope: "system_default" as const,
+          patternType: "seed" as const,
+          sampleKit: "bodhran",
+          hasPremiumAudio: false,
+        },
+        {
+          id: "user-default",
+          name: "User Default",
+          scope: "user_default" as const,
+          patternType: "seed" as const,
+          sampleKit: "generic_click",
+          hasPremiumAudio: false,
+        },
+      ],
+    };
+
+    mocked.loadPatternMock.mockImplementation(async (request) => {
+      currentMetadata =
+        request.selectedPatternId === "user-default"
+          ? {
+              ...currentMetadata,
+              rhythmAbc: userAbc,
+              sampleKit: "generic_click",
+              selectedPatternId: "user-default",
+            }
+          : {
+              ...currentMetadata,
+              rhythmAbc: defaultAbc,
+              sampleKit: "bodhran",
+              selectedPatternId: "system-default",
+            };
+
+      return currentMetadata;
+    });
+    mocked.serviceStub.metadata = () => currentMetadata;
+
+    const view = render(() => <RhythmPlayer tuneTypeName="Reel" />);
+
+    await waitFor(() => {
+      expect(view.getByTestId("rhythm-player-pattern-select")).toBeTruthy();
+    });
+
+    const patternSelect = view.getByTestId(
+      "rhythm-player-pattern-select"
+    ) as HTMLSelectElement;
+    expect(patternSelect.value).toBe("system-default");
+
+    fireEvent.change(patternSelect, {
+      target: { value: "user-default" },
+    });
+
+    await waitFor(() => {
+      expect(mocked.loadPatternMock).toHaveBeenLastCalledWith({
+        genreName: null,
+        tuneTypeName: "Reel",
+        tuneId: null,
+        userId: "auth-user-1",
+        selectedPatternId: "user-default",
+      });
+      expect(patternSelect.value).toBe("user-default");
+    });
+  });
+
   it("shows the current section badge next to the notation", async () => {
     const seedAbc = [
       "X:1",

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -20,7 +20,11 @@ import {
 import { toast } from "solid-sonner";
 import { useAuth } from "@/lib/auth/AuthContext";
 import { createIsMobile } from "@/lib/hooks/useIsMobile";
-import type { RhythmPatternType } from "@/lib/services/RhythmService";
+import type {
+  RhythmPatternCandidate,
+  RhythmPatternCandidateScope,
+  RhythmPatternType,
+} from "@/lib/services/RhythmService";
 import { createRhythmService } from "@/lib/services/RhythmService";
 import { cn } from "@/lib/utils";
 import { AbcNotation } from "../tunes/AbcNotation";
@@ -803,6 +807,33 @@ function collectHighlightTargets(notehead: SVGElement): SVGElement[] {
   return targets;
 }
 
+function getPatternScopeLabel(scope: RhythmPatternCandidateScope): string {
+  switch (scope) {
+    case "user_tune":
+      return "Your tune override";
+    case "tune_default":
+      return "Tune override";
+    case "user_default":
+      return "Your default";
+    case "system_default":
+      return "System default";
+    default:
+      return "Shared pattern";
+  }
+}
+
+function getPatternOptionLabel(candidate: RhythmPatternCandidate): string {
+  const descriptors = [getPatternScopeLabel(candidate.scope)];
+  if (candidate.patternType === "full_track") {
+    descriptors.push("Full track");
+  }
+  if (candidate.hasPremiumAudio) {
+    descriptors.push("Premium loop");
+  }
+
+  return `${candidate.name} (${descriptors.join(" - ")})`;
+}
+
 export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   const { localDb, user } = useAuth();
   const isMobile = createIsMobile();
@@ -815,6 +846,9 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     null
   );
   const [usePremiumLoop, setUsePremiumLoop] = createSignal(false);
+  const [selectedPatternId, setSelectedPatternId] = createSignal<string | null>(
+    null
+  );
   const [selectedStartSection, setSelectedStartSection] = createSignal("start");
   const [showOverflowMenu, setShowOverflowMenu] = createSignal(false);
 
@@ -852,6 +886,12 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   );
   const pulsesPerBar = createMemo(() =>
     beatsPerMeasureFromSignature(metadata()?.rhythmSignature ?? null)
+  );
+  const patternCandidates = createMemo(
+    () => metadata()?.patternCandidates ?? []
+  );
+  const selectedPatternChoiceId = createMemo(
+    () => selectedPatternId() ?? metadata()?.selectedPatternId ?? ""
   );
   const startSectionOptions = createMemo(() =>
     getStructureStartOptions(effectiveStructure())
@@ -972,6 +1012,40 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     }
   });
 
+  createEffect<string | undefined>((previousRequestKey) => {
+    const nextRequestKey = [
+      props.genreName?.trim() || "",
+      props.tuneTypeName?.trim() || "",
+      props.tuneId?.trim() || "",
+      user()?.id ?? "",
+    ].join("|");
+
+    if (
+      previousRequestKey !== undefined &&
+      previousRequestKey !== nextRequestKey &&
+      selectedPatternId() !== null
+    ) {
+      setSelectedPatternId(null);
+    }
+
+    return nextRequestKey;
+  });
+
+  createEffect(() => {
+    const currentSelectedPatternId = selectedPatternId();
+    if (!currentSelectedPatternId) {
+      return;
+    }
+
+    if (
+      !patternCandidates().some(
+        (candidate) => candidate.id === currentSelectedPatternId
+      )
+    ) {
+      setSelectedPatternId(null);
+    }
+  });
+
   const clearActiveBeatTargets = () => {
     for (const target of activeBeatTargets) {
       target.element.classList.remove("tnt-active-note");
@@ -1022,6 +1096,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   createEffect(() => {
     const currentService = service();
     const tuneTypeName = props.tuneTypeName?.trim();
+    const currentSelectedPatternId = selectedPatternId();
 
     if (!currentService || !tuneTypeName) {
       setIsPatternLoading(false);
@@ -1036,6 +1111,9 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
         tuneTypeName,
         tuneId: props.tuneId?.trim() || null,
         userId: user()?.id ?? null,
+        ...(currentSelectedPatternId
+          ? { selectedPatternId: currentSelectedPatternId }
+          : {}),
       })
       .then((nextMetadata) => {
         setSourceRhythmAbc(nextMetadata?.rhythmAbc ?? null);
@@ -1448,6 +1526,31 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
         <Show when={metadata()}>
           {(currentMetadata) => (
             <div class="space-y-3">
+              <Show when={currentMetadata().patternCandidates?.length ?? 0 > 1}>
+                <label class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-300">
+                  <span class="shrink-0 font-medium text-slate-900 dark:text-slate-100">
+                    Pattern:
+                  </span>
+                  <select
+                    value={selectedPatternChoiceId()}
+                    onChange={(event) => {
+                      setSelectedPatternId(event.currentTarget.value || null);
+                    }}
+                    disabled={isPatternLoading()}
+                    class="min-h-11 w-full max-w-[20rem] rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:disabled:bg-slate-900"
+                    data-testid="rhythm-player-pattern-select"
+                  >
+                    <For each={currentMetadata().patternCandidates ?? []}>
+                      {(candidate) => (
+                        <option value={candidate.id}>
+                          {getPatternOptionLabel(candidate)}
+                        </option>
+                      )}
+                    </For>
+                  </select>
+                </label>
+              </Show>
+
               <div class="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-600 dark:text-slate-300">
                 <span class="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
                   Meter {currentMetadata().rhythmSignature || "Unknown"}

--- a/src/lib/services/RhythmService.test.ts
+++ b/src/lib/services/RhythmService.test.ts
@@ -557,6 +557,81 @@ describe("loadRhythmPatternMetadata", () => {
     });
     expect(metadata?.rhythmAbc).toContain("User Default");
   });
+
+  it("returns ranked pattern candidates alongside the selected pattern", async () => {
+    const db = createHierarchicalRhythmDb();
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        tuneId: "tune-1",
+        userId: "user-1",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
+
+    expect(metadata?.selectedPatternId).toBe("user-tune");
+    expect(metadata?.patternCandidates).toEqual([
+      {
+        id: "user-tune",
+        name: "User Tune Override",
+        scope: "user_tune",
+        patternType: "full_track",
+        sampleKit: "bodhran",
+        hasPremiumAudio: true,
+      },
+      {
+        id: "global-tune",
+        name: "Global Tune Override",
+        scope: "tune_default",
+        patternType: "full_track",
+        sampleKit: "bodhran",
+        hasPremiumAudio: false,
+      },
+      {
+        id: "user-default",
+        name: "User Default",
+        scope: "user_default",
+        patternType: "seed",
+        sampleKit: "generic_click",
+        hasPremiumAudio: false,
+      },
+      {
+        id: "system-default",
+        name: "System Default",
+        scope: "system_default",
+        patternType: "seed",
+        sampleKit: "bodhran",
+        hasPremiumAudio: false,
+      },
+    ]);
+  });
+
+  it("honors a selectedPatternId when it matches an eligible candidate", async () => {
+    const db = createHierarchicalRhythmDb();
+
+    const metadata = await loadRhythmPatternMetadata(
+      db,
+      {
+        genreName: "Irish Traditional",
+        tuneTypeName: "Reel",
+        tuneId: "tune-1",
+        userId: "user-1",
+        selectedPatternId: "global-tune",
+      },
+      {
+        sampleBaseUrl: "",
+      }
+    );
+
+    expect(metadata?.selectedPatternId).toBe("global-tune");
+    expect(metadata?.rhythmAbc).toContain("Global Tune Override");
+    expect(metadata?.patternType).toBe("full_track");
+  });
 });
 
 describe("rhythm pattern sqlite migrations", () => {

--- a/src/lib/services/RhythmService.ts
+++ b/src/lib/services/RhythmService.ts
@@ -169,9 +169,26 @@ export interface RhythmPatternRequest {
   tuneTypeName?: string | null;
   tuneId?: string | null;
   userId?: string | null;
+  selectedPatternId?: string | null;
 }
 
 export type RhythmPatternType = "seed" | "full_track";
+
+export type RhythmPatternCandidateScope =
+  | "user_tune"
+  | "tune_default"
+  | "user_default"
+  | "system_default"
+  | "system_pattern";
+
+export interface RhythmPatternCandidate {
+  id: string;
+  name: string;
+  scope: RhythmPatternCandidateScope;
+  patternType: RhythmPatternType;
+  sampleKit: string;
+  hasPremiumAudio: boolean;
+}
 
 export interface RhythmPatternMetadata {
   genreName: string | null;
@@ -187,6 +204,8 @@ export interface RhythmPatternMetadata {
   premiumAudioSource: "database" | null;
   premiumAudioSourceTempoQpm: number | null;
   source: "rhythm_patterns" | "tune_type_fallback";
+  selectedPatternId?: string | null;
+  patternCandidates?: RhythmPatternCandidate[];
 }
 
 export interface PlaybackStartOptions {
@@ -371,6 +390,30 @@ function normalizePatternType(patternType?: string | null): RhythmPatternType {
   return patternType === "full_track" ? "full_track" : "seed";
 }
 
+function getRhythmPatternCandidateScope(row: {
+  tune_id?: string | null;
+  user_id?: string | null;
+  is_default?: number | boolean | null;
+}): RhythmPatternCandidateScope {
+  if (row.user_id && row.tune_id) {
+    return "user_tune";
+  }
+
+  if (row.tune_id) {
+    return "tune_default";
+  }
+
+  if (row.user_id) {
+    return "user_default";
+  }
+
+  if (row.is_default) {
+    return "system_default";
+  }
+
+  return "system_pattern";
+}
+
 function getSampleKitMapping(
   sampleKit?: string | null
 ): Record<number, SampleKitEntry> {
@@ -515,6 +558,7 @@ export async function loadRhythmPatternMetadata(
   const genreFilter = request.genreName?.trim() || null;
   const tuneIdFilter = request.tuneId?.trim() || null;
   const userIdFilter = request.userId?.trim() || null;
+  const selectedPatternIdFilter = request.selectedPatternId?.trim() || null;
 
   if (canUseRhythmPatterns) {
     const rows = await db.all<{
@@ -522,10 +566,16 @@ export async function loadRhythmPatternMetadata(
       tune_type_name: string | null;
       rhythm_signature: string | null;
       tempo_qpm: number | null;
+      pattern_id: string | null;
+      pattern_name: string | null;
       abc_string: string | null;
       sample_kit: string | null;
       premium_audio_url: string | null;
       pattern_type: string | null;
+      tune_id: string | null;
+      user_id: string | null;
+      is_default: number | null;
+      row_num: number | null;
     }>(sql`
       WITH tune_type_match AS (
         SELECT id, name, rhythm
@@ -552,6 +602,8 @@ export async function loadRhythmPatternMetadata(
       ),
       selected_pattern AS (
         SELECT
+          rp.id,
+          rp.name,
           rp.genre_id,
           rp.tune_type_id,
           rp.abc_string,
@@ -568,6 +620,12 @@ export async function loadRhythmPatternMetadata(
               ? sql`rp.pattern_type`
               : sql`CAST('seed' AS TEXT)`
           } AS pattern_type,
+          ${
+            hasTuneIdColumn ? sql`rp.tune_id` : sql`CAST(NULL AS TEXT)`
+          } AS tune_id,
+          ${
+            hasUserIdColumn ? sql`rp.user_id` : sql`CAST(NULL AS TEXT)`
+          } AS user_id,
           rp.is_default,
           rp.part_target,
           ROW_NUMBER() OVER (
@@ -636,27 +694,51 @@ export async function loadRhythmPatternMetadata(
             ? sql`gtt.default_bpm`
             : sql`CAST(NULL AS INTEGER)`
         } AS tempo_qpm,
+        sp.id AS pattern_id,
+        sp.name AS pattern_name,
         sp.abc_string AS abc_string,
         sp.sample_kit AS sample_kit,
         sp.premium_audio_url AS premium_audio_url,
-        sp.pattern_type AS pattern_type
+        sp.pattern_type AS pattern_type,
+        sp.tune_id AS tune_id,
+        sp.user_id AS user_id,
+        sp.is_default AS is_default,
+        sp.row_num AS row_num
       FROM tune_type_match ttm
       LEFT JOIN genre_match gm ON 1 = 1
       LEFT JOIN genre_tune_type gtt
         ON gtt.tune_type_id = ttm.id
        AND (gm.id IS NULL OR gtt.genre_id = gm.id)
-      LEFT JOIN selected_pattern sp ON sp.row_num = 1
-      LIMIT 1
+      LEFT JOIN selected_pattern sp ON 1 = 1
+      ORDER BY sp.row_num
     `);
 
     const row = rows[0];
-    if (row?.tune_type_name && row.abc_string?.trim()) {
+    const candidateRows = rows.filter(
+      (
+        candidateRow
+      ): candidateRow is typeof candidateRow & {
+        pattern_id: string;
+        pattern_name: string;
+      } =>
+        Boolean(
+          candidateRow.pattern_id &&
+            candidateRow.pattern_name &&
+            candidateRow.abc_string?.trim()
+        )
+    );
+    const selectedPatternRow =
+      candidateRows.find(
+        (candidateRow) => candidateRow.pattern_id === selectedPatternIdFilter
+      ) ?? candidateRows.find((candidateRow) => candidateRow.row_num === 1);
+
+    if (row?.tune_type_name && selectedPatternRow?.abc_string?.trim()) {
       const resolvedTempoQpm =
         typeof row.tempo_qpm === "number" && Number.isFinite(row.tempo_qpm)
           ? row.tempo_qpm
           : getDefaultTempoForTuneType(row.tune_type_name);
       const premiumLoop = selectPremiumLoop(sampleBaseUrl, {
-        explicitUrl: row.premium_audio_url,
+        explicitUrl: selectedPatternRow.premium_audio_url,
         tempoQpm: resolvedTempoQpm,
       });
 
@@ -664,15 +746,24 @@ export async function loadRhythmPatternMetadata(
         genreName: row.genre_name ?? genreFilter,
         tuneTypeName: row.tune_type_name,
         rhythmSignature: row.rhythm_signature ?? null,
-        rhythmAbc: row.abc_string.trim(),
-        patternType: normalizePatternType(row.pattern_type),
+        rhythmAbc: selectedPatternRow.abc_string.trim(),
+        patternType: normalizePatternType(selectedPatternRow.pattern_type),
         tempoQpm: resolvedTempoQpm,
-        sampleKit: normalizeSampleKit(row.sample_kit),
+        sampleKit: normalizeSampleKit(selectedPatternRow.sample_kit),
         premiumAudioUrl: premiumLoop?.url ?? null,
         premiumAudioTrimMs: premiumLoop?.trimMs ?? 0,
         premiumAudioSource: premiumLoop?.source ?? null,
         premiumAudioSourceTempoQpm: premiumLoop?.sourceTempoQpm ?? null,
         source: "rhythm_patterns",
+        selectedPatternId: selectedPatternRow.pattern_id,
+        patternCandidates: candidateRows.map((candidateRow) => ({
+          id: candidateRow.pattern_id,
+          name: candidateRow.pattern_name,
+          scope: getRhythmPatternCandidateScope(candidateRow),
+          patternType: normalizePatternType(candidateRow.pattern_type),
+          sampleKit: normalizeSampleKit(candidateRow.sample_kit),
+          hasPremiumAudio: Boolean(candidateRow.premium_audio_url?.trim()),
+        })),
       };
     }
   }
@@ -743,6 +834,8 @@ export async function loadRhythmPatternMetadata(
         premiumAudioSource: null,
         premiumAudioSourceTempoQpm: null,
         source: "tune_type_fallback",
+        selectedPatternId: null,
+        patternCandidates: [],
       };
     }
   }
@@ -785,6 +878,8 @@ export async function loadRhythmPatternMetadata(
     premiumAudioSource: null,
     premiumAudioSourceTempoQpm: null,
     source: "tune_type_fallback",
+    selectedPatternId: null,
+    patternCandidates: [],
   };
 }
 

--- a/src/routes/debug/db.tsx
+++ b/src/routes/debug/db.tsx
@@ -318,6 +318,10 @@ export default function DatabaseBrowser(): ReturnType<Component> {
     { name: "All Tunes", sql: "SELECT * FROM tune ORDER BY title LIMIT 100;" },
     { name: "Repertoires", sql: "SELECT * FROM repertoire;" },
     {
+      name: "Rhythm Patterns",
+      sql: "SELECT * FROM rhythm_patterns ORDER BY genre_id, tune_type_id, name LIMIT 100;",
+    },
+    {
       name: "Daily Practice Queue",
       sql: "SELECT * FROM daily_practice_queue ORDER BY queue_date DESC LIMIT 20;",
     },


### PR DESCRIPTION
## Summary

This PR fixes #635.

Related to #607.

Note: this PR advances #607 but does not close it.

Implemented Slice 3 on the current branch by extending the rhythm resolution path to surface ranked pattern candidates and wiring a selector into the player. RhythmService.ts now preserves the existing precedence order, returns `patternCandidates` plus `selectedPatternId`, and honors an optional `selectedPatternId` in the request. RhythmPlayer.tsx now shows a `Pattern` dropdown only when more than one candidate exists and reloads the selected pattern through the service without changing the broader playback flow.

Added focused regression coverage in RhythmService.test.ts for ranked candidates and explicit selection, and in RhythmPlayer.test.tsx for the new selector UI and request wiring. 

Note that e2e tests do not exist.  Will do that in later PR when the UI is settling more.

## Validation

- `npm run lint && npm run check && npm run typecheck && npm run test:unit`
- Validation passed on both touched suites: RhythmService.test.ts `36/36` and RhythmPlayer.test.tsx `26/26`.
- Hand test, though not yet tested with mulitple patterns
