### PR TITLE
Rhythm accomp fullabc i647

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@ Repository-specific architecture, tech stack details, and patterns (including sy
 ## 1. Reliability & Loop Prevention
 
 - **Verify State:** Before any file edit, read the current state of the file (and the specific section you will change) to ensure symbols and context match your plan.
+- **Generated Files Are Off-Limits:** If a file is listed as generated in any applicable instruction file, or if its header says `AUTO-GENERATED`, `GENERATED`, or `DO NOT EDIT`, do not edit it directly. Change the source input, run the generator, and only keep generator-produced diffs.
 - **Stop on Error:** If an edit results in a syntax error, type error, failing test, or logic loop, stop. Explain what failed, re-read the entire file from disk, then propose a corrected patch.
 - **No Apology-and-Retry Loops:** Do not keep attempting near-identical patches after failures. After 2 failed edit attempts on the same file without new information, stop and ask for guidance.
 - **No Duplicates:** Never append code that already exists. Before finalizing, check for duplicate imports, duplicate exports, repeated helper functions, and repeated config blocks.
@@ -50,6 +51,7 @@ Repository-specific architecture, tech stack details, and patterns (including sy
 - **No Commits / Pushes:** Never commit, push, or open PRs unless explicitly requested.
 - **NEVER COMMIT TO `main` branch:** Never commit to the main branch unless explicitly requested, and even then prefer to create a new branch and open a PR for review.
 - **Validate Changes:** When making code changes, run the smallest relevant checks (typecheck/lint/tests) when practical and report results.
+- **Generated-Output Validation:** If your work touches schema/codegen sources or any generated artifact, run the corresponding generator and its check command before handoff. A failing generator check is a blocker, not a warning.
 - **Keep Architecture Docs Current:** If a task changes architecture, sync boundaries, codegen outputs, runtime wiring, or repository responsibilities, read `ARCHITECTURE.md` before editing and update it in the same change unless the architecture document remains accurate without modification.
 
 ## 6. Multi-Repo Agentic Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,11 +71,14 @@ Primary components:
   - `src/lib/db/client-sqlite.ts`
   - `src/lib/sync/runtime-config.ts`
   - `worker/src/index.ts`
+- **Generated-file edits are forbidden.** If a file is listed here, or if its header says `AUTO-GENERATED`, `GENERATED`, or `DO NOT EDIT`, do not patch it directly.
+- If a task appears to require a generated-file change, edit the source input instead (Supabase migration, `oosync.codegen.config.json`, codegen config, or generator code), run the appropriate generator, and keep only generator-produced diffs.
+- Before editing a file that might be generated, inspect its header first. A generated banner overrides file naming conventions or path heuristics.
 - **Required workflow for schema changes:**
   1. Apply Supabase migration to local Postgres (`npx supabase db push --local` or rhizome equivalent)
   2. Run `npm run codegen:schema` to regenerate all outputs from the live Postgres schema
-  3. Verify: `npm run typecheck && npm run lint && npm run test:unit`
-- If generated output is wrong, fix the **source** (Supabase migration, `oosync.codegen.config.json`, or the codegen generator itself) — never patch generated files.
+  3. Verify: `npm run codegen:schema:check && npm run typecheck && npm run lint && npm run test:unit`
+- If generated output is wrong, fix the **source** (Supabase migration, `oosync.codegen.config.json`, or the codegen generator itself) and regenerate — never patch generated files.
 - Boundary rules are enforced in the standalone `oosync` repo `AGENTS.md` (core must not import app `src/**`; worker must not import app `src/**`; shared/generated is contract-only).
 
 ## UI Principles (Pointers)

--- a/e2e/helpers/local-db-lifecycle.ts
+++ b/e2e/helpers/local-db-lifecycle.ts
@@ -8,6 +8,16 @@ function resolveBaseUrl(path: string = ""): string {
   return new URL(normalizedPath, normalizedBase).toString();
 }
 
+function isRealAppUrl(currentUrl: string): boolean {
+  const baseUrl = String(BASE_URL).replace(/\/+$/, "");
+  return (
+    currentUrl.startsWith(baseUrl) &&
+    !currentUrl.includes("e2e-origin.html") &&
+    currentUrl !== "about:blank" &&
+    !currentUrl.startsWith("data:")
+  );
+}
+
 export async function gotoE2eOrigin(page: Page): Promise<void> {
   await page.goto(resolveBaseUrl("e2e-origin.html"), {
     waitUntil: "domcontentloaded",
@@ -186,6 +196,18 @@ export async function waitForSyncComplete(
   };
 
   while (Date.now() - startTime < timeoutMs) {
+    // Initial sync status only exists on the real app page. Setup can
+    // transiently bounce through e2e-origin.html while storage is being reset,
+    // so recover to the app before polling instead of timing out on the helper page.
+    if (!isRealAppUrl(page.url())) {
+      log.debug(
+        `⏳ waitForSyncComplete is on ${page.url() || "<empty>"}; navigating back to app root`
+      );
+      await page.goto(resolveBaseUrl(), { waitUntil: "domcontentloaded" });
+      await page.waitForTimeout(200);
+      continue;
+    }
+
     let status: {
       version: number;
       successStr: string;

--- a/e2e/helpers/storage-inspection.ts
+++ b/e2e/helpers/storage-inspection.ts
@@ -49,7 +49,7 @@ export async function getIndexedDBSize(page: Page): Promise<number> {
   log.info("📊 Getting IndexedDB size...");
 
   const sizeBytes = await page.evaluate(async () => {
-    if (!navigator.storage || !navigator.storage.estimate) {
+    if (!navigator.storage?.estimate) {
       throw new Error("Storage API not available");
     }
 

--- a/e2e/helpers/test-fixture.ts
+++ b/e2e/helpers/test-fixture.ts
@@ -249,4 +249,4 @@ export const test = base.extend<ITuneTreesFixtures>({
 export { expect } from "@playwright/test";
 
 // Export test users for direct access if needed
-export { TEST_USERS, getTestUserByWorkerIndex };
+export { getTestUserByWorkerIndex, TEST_USERS };

--- a/e2e/tests/flashcard-005-grid-coordination.spec.ts
+++ b/e2e/tests/flashcard-005-grid-coordination.spec.ts
@@ -82,7 +82,9 @@ test.describe
       await app.enableFlashcardMode();
 
       // Verify flashcard shows same evaluation in combobox
-      const evalButton = page.getByTestId(/^recall-eval-[0-9a-f-]+$/i).first();
+      const evalButton = app.flashcardView.getByTestId(
+        /^recall-eval-[0-9a-f-]+$/i
+      );
       await expect(evalButton).toContainText(/Good/i);
     });
 
@@ -275,7 +277,9 @@ test.describe
       await app.enableFlashcardMode();
 
       // Verify "current" flashcard shows "Easy"
-      let evalButton = page.getByTestId(/^recall-eval-[0-9a-f-]+$/i).first();
+      let evalButton = app.flashcardView.getByTestId(
+        /^recall-eval-[0-9a-f-]+$/i
+      );
       await expect(evalButton).toContainText(/Easy/i);
 
       // Navigate backwards to first flashcard
@@ -283,7 +287,7 @@ test.describe
       await page.waitForTimeout(300);
 
       // Verify first flashcard shows "Good"
-      evalButton = page.getByTestId(/^recall-eval-[0-9a-f-]+$/i).first();
+      evalButton = app.flashcardView.getByTestId(/^recall-eval-[0-9a-f-]+$/i);
       await expect(evalButton).toContainText(/Good/i);
 
       // Change first evaluation to "Hard" in flashcards

--- a/e2e/tests/refs-003-audio-player-persistence.spec.ts
+++ b/e2e/tests/refs-003-audio-player-persistence.spec.ts
@@ -13,26 +13,8 @@ import { TuneTreesPage } from "../page-objects/TuneTreesPage";
 let ttPage: TuneTreesPage;
 
 async function readPersistedAudioState(page: Page, referenceId: string) {
-  return page.evaluate(async (id) => {
-    const clientSqliteUrl = new URL(
-      "/src/lib/db/client-sqlite.ts",
-      window.location.origin
-    ).toString();
-    const mediaAssetsUrl = new URL(
-      "/src/lib/db/queries/media-assets.ts",
-      window.location.origin
-    ).toString();
-
-    const { getDb } = await import(clientSqliteUrl);
-    const { getMediaAssetByReferenceId } = await import(mediaAssetsUrl);
-
-    const db = getDb();
-    if (!db) {
-      return null;
-    }
-
-    const mediaAsset = await getMediaAssetByReferenceId(db, id);
-    return mediaAsset?.regionsJson ?? null;
+  return page.evaluate((id) => {
+    return (window as any).__ttTestApi?.readMediaAssetRegions(id) ?? null;
   }, referenceId);
 }
 
@@ -62,6 +44,8 @@ function createSilentWavBuffer(durationSeconds = 1, sampleRate = 8000) {
 }
 
 test.describe("REFS-003: Audio Reference Waveform Persistence", () => {
+  test.setTimeout(180_000);
+
   test.beforeEach(async ({ page, testUser }) => {
     ttPage = new TuneTreesPage(page);
 

--- a/oosync.codegen.config.json
+++ b/oosync.codegen.config.json
@@ -18,7 +18,7 @@
     "dbVersionKeyPrefix": "tunetrees-db-version",
     "outboxBackupKeyPrefix": "tunetrees-outbox-backup",
     "lastSyncTimestampKeyPrefix": "TT_LAST_SYNC_TIMESTAMP",
-    "schemaVersion": "2.0.13-fix-sync-change-log-coverage",
+    "schemaVersion": "2.0.15-refresh-public-rhythm-patterns",
     "databaseVersion": 22,
     "migrationDirectory": "drizzle/migrations/sqlite",
     "migrationFiles": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "wavesurfer.js": "^7.12.6"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.3",
+        "@biomejs/biome": "^2.4.15",
         "@cloudflare/workers-types": "^4.20260516.1",
         "@playwright/test": "^1.60.0",
         "@solidjs/testing-library": "^0.8.10",
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.3.tgz",
-      "integrity": "sha512-cBrjf6PNF6yfL8+kcNl85AjiK2YHNsbU0EvDOwiZjBPbMbQ5QcgVGFpjD0O52p8nec5O8NYw7PKw3xUR7fPAkQ==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.15.tgz",
+      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -1776,20 +1776,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.4.3",
-        "@biomejs/cli-darwin-x64": "2.4.3",
-        "@biomejs/cli-linux-arm64": "2.4.3",
-        "@biomejs/cli-linux-arm64-musl": "2.4.3",
-        "@biomejs/cli-linux-x64": "2.4.3",
-        "@biomejs/cli-linux-x64-musl": "2.4.3",
-        "@biomejs/cli-win32-arm64": "2.4.3",
-        "@biomejs/cli-win32-x64": "2.4.3"
+        "@biomejs/cli-darwin-arm64": "2.4.15",
+        "@biomejs/cli-darwin-x64": "2.4.15",
+        "@biomejs/cli-linux-arm64": "2.4.15",
+        "@biomejs/cli-linux-arm64-musl": "2.4.15",
+        "@biomejs/cli-linux-x64": "2.4.15",
+        "@biomejs/cli-linux-x64-musl": "2.4.15",
+        "@biomejs/cli-win32-arm64": "2.4.15",
+        "@biomejs/cli-win32-x64": "2.4.15"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.3.tgz",
-      "integrity": "sha512-eOafSFlI/CF4id2tlwq9CVHgeEqvTL5SrhWff6ZORp6S3NL65zdsR3ugybItkgF8Pf4D9GSgtbB6sE3UNgOM9w==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.15.tgz",
+      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
       "cpu": [
         "arm64"
       ],
@@ -1804,9 +1804,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.3.tgz",
-      "integrity": "sha512-V2+av4ilbWcBMNufTtMMXVW00nPwyIjI5qf7n9wSvUaZ+tt0EvMGk46g9sAFDJBEDOzSyoRXiSP6pCvKTOEbPA==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.15.tgz",
+      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
       "cpu": [
         "x64"
       ],
@@ -1821,9 +1821,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.3.tgz",
-      "integrity": "sha512-0m+O0x9FgK99FAwDK+fiDtjs2wnqq7bvfj17KJVeCkTwT/liI+Q9njJG7lwXK0iSJVXeFNRIxukpVI3SifMYAA==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.15.tgz",
+      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
       "cpu": [
         "arm64"
       ],
@@ -1838,9 +1838,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.3.tgz",
-      "integrity": "sha512-QuFzvsGo8BA4Xm7jGX5idkw6BqFblcCPySMTvq0AhGYnhUej5VJIDJbmTKfHqwjHepZiC4fA+T5i6wmiZolZNw==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.15.tgz",
+      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
       "cpu": [
         "arm64"
       ],
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.3.tgz",
-      "integrity": "sha512-NVqh0saIU0u5OfOp/0jFdlKRE59+XyMvWmtx0f6Nm/2OpdxBl04coRIftBbY9d1gfu+23JVv4CItAqPYrjYh5w==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.15.tgz",
+      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
       "cpu": [
         "x64"
       ],
@@ -1872,9 +1872,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.3.tgz",
-      "integrity": "sha512-qEc0OCpj/uytruQ4wLM0yWNJLZy0Up8H1Er5MW3SrstqM6J2d4XqdNA86xzCy8MQCHpoVZ3lFye3GBlIL4/ljw==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.15.tgz",
+      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
       "cpu": [
         "x64"
       ],
@@ -1889,9 +1889,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.3.tgz",
-      "integrity": "sha512-gRO96vrIARilv/Cp2ZnmNNL5LSZg3RO75GPp13hsLO3N4YVpE7saaMDp2bcyV48y2N2Pbit1brkGVGta0yd6VQ==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.15.tgz",
+      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
       "cpu": [
         "arm64"
       ],
@@ -1906,9 +1906,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.3.tgz",
-      "integrity": "sha512-vSm/vOJe06pf14aGHfHl3Ar91Nlx4YYmohElDJ+17UbRwe99n987S/MhAlQOkONqf1utJor04ChkCPmKb8SWdw==",
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.15.tgz",
+      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
       "cpu": [
         "x64"
       ],
@@ -1964,7 +1964,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "dev": true,
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "wavesurfer.js": "^7.12.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.3",
+    "@biomejs/biome": "^2.4.15",
     "@cloudflare/workers-types": "^4.20260516.1",
     "@playwright/test": "^1.60.0",
     "@solidjs/testing-library": "^0.8.10",

--- a/src/components/rhythm/RhythmPlayer.test.tsx
+++ b/src/components/rhythm/RhythmPlayer.test.tsx
@@ -201,12 +201,12 @@ describe("RhythmPlayer", () => {
     const noteheads = [
       makeNotehead(0, "a1"),
       makeNotehead(0, "a2"),
-      makeNotehead(0, "a3"),
-      makeNotehead(0, "a4"),
-      makeNotehead(1, "b1"),
-      makeNotehead(1, "b2"),
-      makeNotehead(1, "b3"),
-      makeNotehead(1, "b4"),
+      makeNotehead(1, "a3"),
+      makeNotehead(1, "a4"),
+      makeNotehead(2, "b1"),
+      makeNotehead(2, "b2"),
+      makeNotehead(3, "b3"),
+      makeNotehead(3, "b4"),
     ];
 
     const sourceAbc = [
@@ -232,7 +232,7 @@ describe("RhythmPlayer", () => {
         "A2A2B2B2",
         3
       )?.getAttribute("data-note-id")
-    ).toBe("a1");
+    ).toBe("a3");
     expect(
       resolveStructuredDisplayNotehead(
         noteheads,
@@ -247,6 +247,104 @@ describe("RhythmPlayer", () => {
         sourceAbc,
         "A2A2B2B2",
         7
+      )?.getAttribute("data-note-id")
+    ).toBe("b3");
+  });
+
+  it("maps compact full-track repeats by section when each section spans multiple staff lines", () => {
+    const makeNotehead = (lineIndex: number, id: string) => {
+      const noteGroup = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "g"
+      );
+      noteGroup.setAttribute("class", `abcjs-note abcjs-l${lineIndex}`);
+
+      const notehead = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "path"
+      );
+      notehead.setAttribute("class", "abcjs-notehead");
+      notehead.setAttribute("data-note-id", id);
+      noteGroup.appendChild(notehead);
+      return notehead;
+    };
+
+    const noteheads = [
+      makeNotehead(0, "a1"),
+      makeNotehead(0, "a2"),
+      makeNotehead(0, "a3"),
+      makeNotehead(0, "a4"),
+      makeNotehead(1, "a5"),
+      makeNotehead(1, "a6"),
+      makeNotehead(1, "a7"),
+      makeNotehead(1, "a8"),
+      makeNotehead(2, "b1"),
+      makeNotehead(2, "b2"),
+      makeNotehead(2, "b3"),
+      makeNotehead(2, "b4"),
+      makeNotehead(3, "b5"),
+      makeNotehead(3, "b6"),
+      makeNotehead(3, "b7"),
+      makeNotehead(3, "b8"),
+    ];
+
+    const sourceAbc = [
+      "X:1",
+      "M:4/4",
+      "L:1/4",
+      "K:clef=perc",
+      "|: A | B | C | D |",
+      "E | F | G | A :|",
+      "|: B | C | D | E |",
+      "F | G | A | B :|",
+    ].join("\n");
+
+    expect(
+      resolveStructuredDisplayNotehead(
+        noteheads,
+        sourceAbc,
+        "AABB",
+        1
+      )?.getAttribute("data-note-id")
+    ).toBe("a1");
+    expect(
+      resolveStructuredDisplayNotehead(
+        noteheads,
+        sourceAbc,
+        "AABB",
+        5
+      )?.getAttribute("data-note-id")
+    ).toBe("a5");
+    expect(
+      resolveStructuredDisplayNotehead(
+        noteheads,
+        sourceAbc,
+        "AABB",
+        9
+      )?.getAttribute("data-note-id")
+    ).toBe("a1");
+    expect(
+      resolveStructuredDisplayNotehead(
+        noteheads,
+        sourceAbc,
+        "AABB",
+        13
+      )?.getAttribute("data-note-id")
+    ).toBe("a5");
+    expect(
+      resolveStructuredDisplayNotehead(
+        noteheads,
+        sourceAbc,
+        "AABB",
+        17
+      )?.getAttribute("data-note-id")
+    ).toBe("b1");
+    expect(
+      resolveStructuredDisplayNotehead(
+        noteheads,
+        sourceAbc,
+        "AABB",
+        25
       )?.getAttribute("data-note-id")
     ).toBe("b1");
   });
@@ -391,9 +489,9 @@ describe("RhythmPlayer", () => {
     expect(playbackAbc).toContain("M:4/4");
     expect(playbackAbc).toContain("L:1/8");
     expect(playbackAbc).toContain("K:clef=perc");
-    expect(playbackAbc).toContain(
-      "| C2 A2 C2 A2 | C2 A2 C2 A2 | C2 A2 C2 A2 | C2 A2 C2 A2 |"
-    );
+    expect(playbackAbc).toContain("P:A");
+    expect(playbackAbc).toContain("P:B");
+    expect(playbackAbc).toContain("| C2 A2 C2 A2 | C2 A2 C2 A2 |");
   });
 
   it("repeats structured seed sections in playback order", async () => {
@@ -798,6 +896,94 @@ describe("RhythmPlayer", () => {
         selectedPatternId: "user-default",
       });
       expect(patternSelect.value).toBe("user-default");
+    });
+  });
+
+  it("shows the loaded pattern when a selection request resolves to a different candidate", async () => {
+    const defaultAbc = [
+      "X:1",
+      "T:System Default",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      "|: C2 A2 C2 A2 :|",
+    ].join("\n");
+    const userAbc = [
+      "X:1",
+      "T:User Default",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      "|: D2 A2 D2 A2 :|",
+    ].join("\n");
+
+    const patternCandidates = [
+      {
+        id: "system-default",
+        name: "System Default",
+        scope: "system_default" as const,
+        patternType: "seed" as const,
+        sampleKit: "bodhran",
+        hasPremiumAudio: false,
+      },
+      {
+        id: "user-default",
+        name: "User Default",
+        scope: "user_default" as const,
+        patternType: "seed" as const,
+        sampleKit: "generic_click",
+        hasPremiumAudio: false,
+      },
+    ];
+    let currentPatternId: "system-default" | "user-default" = "system-default";
+
+    const buildMetadata = (
+      patternId: "system-default" | "user-default"
+    ): RhythmPatternMetadata => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: patternId === "user-default" ? userAbc : defaultAbc,
+      rhythmSignature: "4/4",
+      patternType: "seed",
+      tempoQpm: 112,
+      sampleKit: patternId === "user-default" ? "generic_click" : "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns",
+      selectedPatternId: patternId,
+      patternCandidates,
+    });
+
+    mocked.loadPatternMock.mockImplementation(async (request) => {
+      currentPatternId =
+        request.selectedPatternId === "user-default"
+          ? "system-default"
+          : "system-default";
+
+      return buildMetadata(currentPatternId);
+    });
+    mocked.serviceStub.metadata = () => buildMetadata(currentPatternId);
+
+    const view = render(() => <RhythmPlayer tuneTypeName="Reel" />);
+
+    await waitFor(() => {
+      expect(view.getByTestId("rhythm-player-pattern-select")).toBeTruthy();
+    });
+
+    const patternSelect = view.getByTestId(
+      "rhythm-player-pattern-select"
+    ) as HTMLSelectElement;
+    expect(patternSelect.value).toBe("system-default");
+
+    fireEvent.change(patternSelect, {
+      target: { value: "user-default" },
+    });
+
+    await waitFor(() => {
+      expect(mocked.loadPatternMock).toHaveBeenCalledTimes(2);
+      expect(patternSelect.value).toBe("system-default");
     });
   });
 
@@ -1713,6 +1899,129 @@ describe("RhythmPlayer", () => {
     );
   });
 
+  it("renders full_track notation without rewriting the tune body when no structure is provided", async () => {
+    const fullTrackAbc = [
+      "X:7",
+      "T:Full Tune Display",
+      "Q:1/4=112",
+      "M:6/8",
+      "L:1/8",
+      "K:clef=perc",
+      "P:A",
+      "|: C2 E G | A2 c e :|",
+      "P:B",
+      "|: e2 c A | G2 E C :|",
+    ].join("\n");
+
+    mocked.loadPatternMock.mockResolvedValue({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Jig",
+      rhythmAbc: fullTrackAbc,
+      rhythmSignature: "6/8",
+      patternType: "full_track",
+      tempoQpm: 112,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns",
+    });
+    mocked.serviceStub.metadata = () => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Jig",
+      rhythmAbc: fullTrackAbc,
+      rhythmSignature: "6/8",
+      patternType: "full_track" as const,
+      tempoQpm: 112,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+    });
+
+    render(() => <RhythmPlayer tuneTypeName="Jig" />);
+
+    await waitFor(() => {
+      expect(mocked.renderAbcMock).toHaveBeenCalled();
+    });
+
+    const renderedAbc = mocked.renderAbcMock.mock.calls.at(-1)?.[1] as string;
+    expect(renderedAbc).toContain("X:1");
+    expect(renderedAbc).toContain("M:6/8");
+    expect(renderedAbc).toContain("L:1/8");
+    expect(renderedAbc).toContain("K:clef=perc");
+    expect(renderedAbc).toContain("P:A");
+    expect(renderedAbc).toContain("|: C2 E G | A2 c e :|");
+    expect(renderedAbc).toContain("P:B");
+    expect(renderedAbc).toContain("|: e2 c A | G2 E C :|");
+    expect(renderedAbc).not.toContain("T:Full Tune Display");
+    expect(renderedAbc).not.toContain("Q:1/4=112");
+  });
+
+  it("renders compact full_track notation using structure repeats", async () => {
+    const fullTrackAbc = [
+      "X:1",
+      "T:Compact Full Tune",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      `P:A\n| ${Array.from({ length: 8 }, () => "C2 A2 C2 A2").join(" | ")} |`,
+      `P:B\n| ${Array.from({ length: 8 }, () => "C2 c2 C2 c2").join(" | ")} |`,
+    ].join("\n");
+
+    mocked.loadPatternMock.mockResolvedValue({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: fullTrackAbc,
+      rhythmSignature: "4/4",
+      patternType: "full_track",
+      tempoQpm: 112,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns",
+    });
+    mocked.serviceStub.metadata = () => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: fullTrackAbc,
+      rhythmSignature: "4/4",
+      patternType: "full_track" as const,
+      tempoQpm: 112,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+    });
+
+    render(() => <RhythmPlayer tuneTypeName="Reel" structure="AABB" />);
+
+    await waitFor(() => {
+      expect(mocked.renderAbcMock).toHaveBeenCalled();
+    });
+
+    const renderedAbc = mocked.renderAbcMock.mock.calls.at(-1)?.[1] as string;
+    expect(renderedAbc).toContain("X:1");
+    expect(renderedAbc).toContain("M:4/4");
+    expect(renderedAbc).toContain("L:1/8");
+    expect(renderedAbc).toContain("K:clef=perc");
+    expect(renderedAbc).toContain("P:A");
+    expect(renderedAbc).toContain(
+      `| ${Array.from({ length: 4 }, () => "C2 A2 C2 A2").join(" | ")} |`
+    );
+    expect(renderedAbc).toContain("P:B");
+    expect(renderedAbc).toContain(
+      `| ${Array.from({ length: 4 }, () => "C2 c2 C2 c2").join(" | ")} |`
+    );
+  });
+
   it("shows the premium loop switch only when metadata exposes a premium audio URL", async () => {
     const metadata = {
       genreName: "Irish Traditional",
@@ -1797,8 +2106,13 @@ describe("RhythmPlayer", () => {
     expect(renderedAbc).toContain("M:6/8");
     expect(renderedAbc).toContain("L:1/8");
     expect(renderedAbc).toContain("K:clef=perc");
+    expect(renderedAbc).toContain("P:A");
+    expect(renderedAbc).toContain("P:B");
     expect(renderedAbc).toContain(
-      "|:C2 c C c c|C2 c C c c|C2 c C c c|C2 c C c c|C2 c C c c|C2 c C c c|C2 c C c c|C2 c C c c:|"
+      "|: C2 c C c c | C2 c C c c | C2 c C c c | C2 c C c c |"
+    );
+    expect(renderedAbc).toContain(
+      "| C2 c C c c | C2 c C c c | C2 c C c c | C2 c C c c :|"
     );
     expect(renderedAbc).not.toContain("$");
     expect(renderedAbc).not.toContain("T:");

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -2055,7 +2055,6 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                         {(candidate) => (
                           <option
                             value={candidate.id}
-                            selected={candidate.id === currentPatternChoiceId()}
                           >
                             {getPatternOptionLabel(candidate)}
                           </option>

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -262,7 +262,7 @@ function normalizeAbcBodyBars(abcBody: string): string[] {
     .replace(/^\s*\|:/, "")
     .replace(/:\|\s*$/, "")
     .split("|")
-    .map((segment) => segment.trim())
+    .map((segment) => segment.replace(/^:+|:+$/g, "").trim())
     .filter(Boolean);
 }
 
@@ -618,20 +618,21 @@ export function updateStructuredDisplayPartLabels(
     return;
   }
 
-  const collapsedSections = collapseStructureSections(
-    parseStructure(structure)
-  );
+  const parts = parseStructure(structure);
+  const collapsedSections = collapseStructureSections(parts);
   const labelTargets = getDisplayPartLabelTargets(container);
+  const displaySections =
+    labelTargets.length === parts.length ? parts : collapsedSections;
   if (
-    collapsedSections.length === 0 ||
+    displaySections.length === 0 ||
     labelTargets.length === 0 ||
-    labelTargets.length !== collapsedSections.length
+    labelTargets.length !== displaySections.length
   ) {
     return;
   }
 
   for (const [index, target] of labelTargets.entries()) {
-    const baseLabel = collapsedSections[index]?.label ?? "";
+    const baseLabel = displaySections[index]?.label ?? "";
     for (const element of target.elements) {
       element.textContent = baseLabel;
     }
@@ -650,7 +651,10 @@ export function updateStructuredDisplayPartLabels(
     position.sectionPass > 1
       ? `${position.part.label}${position.sectionPass}`
       : position.part.label;
-  const activeTarget = labelTargets[position.displaySectionIndex];
+  const activeTarget =
+    labelTargets.length === parts.length
+      ? labelTargets[position.activePartIndex]
+      : labelTargets[position.displaySectionIndex];
   if (!activeTarget) {
     return;
   }
@@ -681,17 +685,55 @@ export function resolveStructuredDisplayNotehead(
     currentBeatIndex
   );
   const parts = parseStructure(structure);
-  const collapsedSections = collapseStructureSections(parts);
-  if (!position || parts.length === 0 || collapsedSections.length === 0) {
+  if (!position || parts.length === 0) {
     return null;
   }
 
   const lineGroups = groupNoteheadsByDisplayLine(noteheads);
-  if (lineGroups.length !== collapsedSections.length) {
+  const compactTemplates = buildCompactDisplaySectionTemplates(
+    sourceAbc,
+    parts
+  );
+  if (compactTemplates.length > 0) {
+    const template = compactTemplates.find(
+      (candidate) => candidate.key === getSectionTemplateKey(position.part)
+    );
+
+    if (!template) {
+      return null;
+    }
+
+    let remainingBeatIndex = position.remainingBeatIndex;
+    for (
+      let lineOffset = 0;
+      lineOffset < template.lineEventCounts.length;
+      lineOffset += 1
+    ) {
+      const lineEventCount = template.lineEventCounts[lineOffset] ?? 0;
+      if (remainingBeatIndex < lineEventCount) {
+        const lineGroup = lineGroups[template.startLineIndex + lineOffset];
+        if (!lineGroup || lineGroup.length === 0) {
+          return null;
+        }
+
+        return lineGroup[remainingBeatIndex % lineGroup.length] ?? null;
+      }
+
+      remainingBeatIndex -= lineEventCount;
+    }
+
     return null;
   }
 
-  const lineGroup = lineGroups[position.displaySectionIndex];
+  const displayLineIndex =
+    lineGroups.length === parts.length
+      ? position.activePartIndex
+      : position.displaySectionIndex;
+  if (displayLineIndex < 0 || displayLineIndex >= lineGroups.length) {
+    return null;
+  }
+
+  const lineGroup = lineGroups[displayLineIndex];
   if (!lineGroup || lineGroup.length === 0) {
     return null;
   }
@@ -716,6 +758,79 @@ function splitAbcSections(abc: string): {
   };
 }
 
+function getAbcBodyLines(abc: string): string[] {
+  return abc
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .filter((line) => !/^[A-Z]:/.test(line));
+}
+
+interface CompactDisplaySectionTemplate {
+  key: string;
+  startLineIndex: number;
+  lineEventCounts: number[];
+}
+
+function buildCompactDisplaySectionTemplates(
+  abc: string,
+  parts: StructurePart[]
+): CompactDisplaySectionTemplate[] {
+  const { bodyBars } = splitAbcSections(abc);
+  const distinctParts = getDistinctStructureParts(parts);
+  const distinctStructureBarCount = distinctParts.reduce(
+    (sum, part) => sum + part.bars,
+    0
+  );
+
+  if (
+    distinctParts.length === 0 ||
+    distinctParts.length === parts.length ||
+    bodyBars.length > distinctStructureBarCount
+  ) {
+    return [];
+  }
+
+  const bodyLines = getAbcBodyLines(abc);
+  if (bodyLines.length === 0) {
+    return [];
+  }
+
+  const templates: CompactDisplaySectionTemplate[] = [];
+  let lineOffset = 0;
+
+  for (const part of distinctParts) {
+    let consumedBars = 0;
+    const lineEventCounts: number[] = [];
+    const startLineIndex = lineOffset;
+
+    while (lineOffset < bodyLines.length && consumedBars < part.bars) {
+      const line = bodyLines[lineOffset] ?? "";
+      const lineBars = normalizeAbcBodyBars(line);
+      const eventCount = lineBars.reduce(
+        (sum, bar) => sum + countBarEvents(bar),
+        0
+      );
+
+      consumedBars += lineBars.length;
+      lineEventCounts.push(eventCount);
+      lineOffset += 1;
+    }
+
+    if (lineEventCounts.length === 0 || consumedBars < part.bars) {
+      return [];
+    }
+
+    templates.push({
+      key: getSectionTemplateKey(part),
+      startLineIndex,
+      lineEventCounts,
+    });
+  }
+
+  return templates;
+}
+
 function normalizeDisplayHeaderLine(line: string): string | null {
   if (line.startsWith("X:")) {
     return "X:1";
@@ -732,7 +847,35 @@ function normalizeDisplayHeaderLine(line: string): string | null {
   return line;
 }
 
-function buildSectionDisplayBody(
+function wrapDisplayBodyLine(line: string, maxBarsPerLine = 4): string[] {
+  const trimmed = line.trim();
+  if (!trimmed || /^P:/.test(trimmed)) {
+    return trimmed ? [trimmed] : [];
+  }
+
+  const bodyBars = normalizeAbcBodyBars(trimmed);
+  if (bodyBars.length === 0 || bodyBars.length <= maxBarsPerLine) {
+    return [trimmed];
+  }
+
+  const hasRepeatStart = /^\|:/.test(trimmed);
+  const hasRepeatEnd = /:\|\s*$/.test(trimmed);
+  const wrappedLines: string[] = [];
+
+  for (let index = 0; index < bodyBars.length; index += maxBarsPerLine) {
+    const chunk = bodyBars.slice(index, index + maxBarsPerLine);
+    const isFirstChunk = index === 0;
+    const isLastChunk = index + maxBarsPerLine >= bodyBars.length;
+    const prefix = isFirstChunk && hasRepeatStart ? "|: " : "| ";
+    const suffix = isLastChunk && hasRepeatEnd ? " :|" : " |";
+
+    wrappedLines.push(`${prefix}${chunk.join(" | ")}${suffix}`);
+  }
+
+  return wrappedLines;
+}
+
+function buildStructuredFullTrackBody(
   bodyBars: string[],
   parts: StructurePart[]
 ): string[] {
@@ -746,12 +889,52 @@ function buildSectionDisplayBody(
     const sectionBars =
       templates.get(getSectionTemplateKey(section))?.bodyBars ??
       getSectionBodyBars(bodyBars, section.bars);
-
-    const body = sectionBars.join("|");
-    const sectionBody = section.repeatCount > 1 ? `|:${body}:|` : `|${body}|`;
+    const body = sectionBars.join(" | ");
+    const sectionBody =
+      section.repeatCount > 1 ? `|: ${body} :|` : `| ${body} |`;
 
     return [`P:${section.label}`, sectionBody];
   });
+}
+
+function buildStructuredFullTrackAbc(
+  abc: string,
+  structure: string | null | undefined
+): string {
+  if (!normalizeStructure(structure)) {
+    return abc;
+  }
+
+  const parts = parseStructure(structure);
+  const { headerLines, bodyBars } = splitAbcSections(abc);
+  const totalStructuredBarCount = parts.reduce(
+    (sum, part) => sum + part.bars,
+    0
+  );
+
+  if (bodyBars.length === 0 || bodyBars.length >= totalStructuredBarCount) {
+    return abc;
+  }
+
+  const bodyLines = buildStructuredFullTrackBody(bodyBars, parts);
+
+  return bodyLines.length > 0 ? [...headerLines, ...bodyLines].join("\n") : abc;
+}
+
+function normalizeFullTrackDisplayAbc(abc: string): string {
+  return abc
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .flatMap((line) => {
+      if (!/^[A-Z]:/.test(line)) {
+        return wrapDisplayBodyLine(line);
+      }
+
+      const normalizedLine = normalizeDisplayHeaderLine(line);
+      return normalizedLine ? [normalizedLine] : [];
+    })
+    .join("\n");
 }
 
 function buildDisplayRhythmAbc(
@@ -759,27 +942,10 @@ function buildDisplayRhythmAbc(
   patternType: RhythmPatternType,
   structure: string | null | undefined
 ): string {
-  const { headerLines, bodyBars } = splitAbcSections(abc);
-  const normalizedHeaders = headerLines
-    .map(normalizeDisplayHeaderLine)
-    .filter((line): line is string => Boolean(line));
-  const headers = [
-    normalizedHeaders.find((line) => line.startsWith("X:")) ?? "X:1",
-    ...normalizedHeaders.filter((line) => !line.startsWith("X:")),
-  ];
+  const displaySourceAbc =
+    patternType === "seed" ? buildStructuredFullTrackAbc(abc, structure) : abc;
 
-  if (patternType === "seed" && normalizeStructure(structure)) {
-    const sectionLines = buildSectionDisplayBody(
-      bodyBars,
-      parseStructure(structure)
-    );
-    if (sectionLines.length > 0) {
-      return [...headers, ...sectionLines].join("\n");
-    }
-  }
-
-  const body = bodyBars.length > 0 ? `|:${bodyBars.join("|")}:|` : "";
-  return [...headers, body].filter(Boolean).join("\n");
+  return normalizeFullTrackDisplayAbc(displaySourceAbc);
 }
 
 function expandRhythmAbcByPatternType(
@@ -931,7 +1097,10 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     null
   );
   const [usePremiumLoop, setUsePremiumLoop] = createSignal(false);
-  const [selectedPatternId, setSelectedPatternId] = createSignal<string | null>(
+  const [requestedPatternId, setRequestedPatternId] = createSignal<
+    string | null
+  >(null);
+  const [currentPatternId, setCurrentPatternId] = createSignal<string | null>(
     null
   );
   const [selectedStartSection, setSelectedStartSection] = createSignal("start");
@@ -1003,17 +1172,18 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   const patternCandidates = createMemo(
     () => metadata()?.patternCandidates ?? []
   );
-  const selectedPatternChoiceId = createMemo(
-    () => selectedPatternId() ?? metadata()?.selectedPatternId ?? ""
+  const displayedPatternId = createMemo(
+    () => currentPatternId() ?? requestedPatternId() ?? null
   );
-  const selectedPatternCandidate = createMemo(
+  const currentPattern = createMemo(
     () =>
       patternCandidates().find(
-        (candidate) => candidate.id === selectedPatternChoiceId()
+        (candidate) => candidate.id === displayedPatternId()
       ) ?? null
   );
+  const currentPatternChoiceId = createMemo(() => displayedPatternId() ?? "");
   const selectedEditablePatternId = createMemo(() => {
-    const candidate = selectedPatternCandidate();
+    const candidate = currentPattern();
     if (!candidate) {
       return null;
     }
@@ -1054,9 +1224,19 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
         barsBefore: 0,
       }
   );
+  const unifiedSourceAbc = createMemo(() => {
+    const abc = sourceRhythmAbc();
+    if (!abc) {
+      return null;
+    }
+
+    return (metadata()?.patternType ?? "seed") === "seed"
+      ? buildStructuredFullTrackAbc(abc, effectiveStructure())
+      : abc;
+  });
   const selectedPlaybackStartState = createMemo(() =>
     getStructuredPlaybackStartState(
-      sourceRhythmAbc(),
+      unifiedSourceAbc(),
       effectiveStructure(),
       selectedStartSectionOption()
     )
@@ -1072,8 +1252,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
    * rendered staff shows the full multi-section pattern, not just a 1-2 bar loop.
    */
   const expandedAbc = createMemo(() => {
-    const abc = sourceRhythmAbc();
-    const patternType = metadata()?.patternType ?? "seed";
+    const abc = unifiedSourceAbc();
     const structure = effectiveStructure();
     if (!abc) return null;
     if (!structure) return abc;
@@ -1083,21 +1262,17 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
 
     return expandRhythmAbcByPatternType(
       abc,
-      patternType,
+      "full_track",
       structuredBarCount,
       structure
     );
   });
 
   const displayAbc = createMemo(() => {
-    const abc = sourceRhythmAbc();
+    const abc = unifiedSourceAbc();
     if (!abc) return null;
 
-    return buildDisplayRhythmAbc(
-      abc,
-      metadata()?.patternType ?? "seed",
-      effectiveStructure()
-    );
+    return buildDisplayRhythmAbc(abc, "full_track", effectiveStructure());
   });
 
   const playbackAbc = createMemo(() => {
@@ -1119,7 +1294,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   const currentBar = createMemo(() => currentMeasure() || 0);
   const currentSectionLabel = createMemo(() =>
     getStructuredSectionLabel(
-      sourceRhythmAbc(),
+      unifiedSourceAbc(),
       effectiveStructure(),
       currentBeatIndex()
     )
@@ -1149,7 +1324,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
 
   const openCreateCustomPatternEditor = () => {
     const tuneTypeName = rhythmPatternContext().tuneTypeName ?? "Custom";
-    const selectedCandidateName = selectedPatternCandidate()?.name?.trim();
+    const selectedCandidateName = currentPattern()?.name?.trim();
     const baseName = selectedCandidateName
       ? `${selectedCandidateName} copy`
       : `My ${tuneTypeName} pattern`;
@@ -1269,7 +1444,8 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
           : await createEditableRhythmPattern(db, payload);
 
       setCustomPatternId(savedPattern.id);
-      setSelectedPatternId(savedPattern.id);
+      setRequestedPatternId(savedPattern.id);
+      setCurrentPatternId(null);
       setPatternReloadKey((current) => current + 1);
       closeCustomPatternEditor();
     } catch (error) {
@@ -1299,8 +1475,9 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     try {
       await deleteEditableRhythmPattern(db, patternId, currentUserId);
 
-      if (selectedPatternChoiceId() === patternId) {
-        setSelectedPatternId(null);
+      if (currentPatternChoiceId() === patternId) {
+        setRequestedPatternId(null);
+        setCurrentPatternId(null);
       }
 
       setPatternReloadKey((current) => current + 1);
@@ -1330,6 +1507,17 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     }
   };
 
+  const handlePatternSelectionChange = (value: string) => {
+    const nextPatternId = value.trim() || null;
+
+    if (nextPatternId === currentPatternChoiceId()) {
+      return;
+    }
+
+    setCurrentPatternId(null);
+    setRequestedPatternId(nextPatternId);
+  };
+
   createEffect(() => {
     const options = startSectionOptions();
     if (!options.some((option) => option.value === selectedStartSection())) {
@@ -1349,9 +1537,10 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     if (
       previousRequestKey !== undefined &&
       previousRequestKey !== nextRequestKey &&
-      selectedPatternId() !== null
+      (requestedPatternId() !== null || currentPatternId() !== null)
     ) {
-      setSelectedPatternId(null);
+      setRequestedPatternId(null);
+      setCurrentPatternId(null);
     }
 
     if (
@@ -1413,9 +1602,9 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
 
   createEffect(() => {
     patternReloadKey();
+    const currentRequestedPatternId = requestedPatternId();
     const currentService = service();
     const tuneTypeName = props.tuneTypeName?.trim();
-    const currentSelectedPatternId = selectedPatternId();
 
     if (!currentService || !tuneTypeName) {
       setIsPatternLoading(false);
@@ -1431,11 +1620,12 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
         tuneTypeName,
         tuneId: props.tuneId?.trim() || null,
         userId: user()?.id ?? null,
-        ...(currentSelectedPatternId
-          ? { selectedPatternId: currentSelectedPatternId }
+        ...(currentRequestedPatternId
+          ? { selectedPatternId: currentRequestedPatternId }
           : {}),
       })
       .then((nextMetadata) => {
+        setCurrentPatternId(nextMetadata?.selectedPatternId?.trim() || null);
         setSourceRhythmAbc(nextMetadata?.rhythmAbc ?? null);
       })
       .finally(() => {
@@ -1461,7 +1651,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
 
   createEffect(() => {
     const container = getNotationContainer();
-    const sourceAbc = sourceRhythmAbc();
+    const sourceAbc = unifiedSourceAbc();
     const structure = effectiveStructure();
     const beatIndex = currentBeatIndex();
 
@@ -1481,7 +1671,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     const container = getNotationContainer();
     const beatIndex = currentBeatIndex();
     const rhythmAbc = displayAbc();
-    const sourceAbc = sourceRhythmAbc();
+    const sourceAbc = unifiedSourceAbc();
     const structure = effectiveStructure();
 
     if (!container || !rhythmAbc) {
@@ -1846,32 +2036,35 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
         <Show when={metadata()}>
           {(currentMetadata) => (
             <div class="space-y-3">
-              <Show when={patternCandidates().length > 1}>
-                <label class="flex items-center gap-3 text-sm text-slate-600 dark:text-slate-300">
-                  <span class="shrink-0 font-medium text-slate-900 dark:text-slate-100">
-                    Pattern:
-                  </span>
-                  <select
-                    value={selectedPatternChoiceId()}
-                    onChange={(event) => {
-                      setSelectedPatternId(event.currentTarget.value || null);
-                    }}
-                    disabled={isPatternLoading()}
-                    class="min-h-11 w-full max-w-[20rem] rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:disabled:bg-slate-900"
-                    data-testid="rhythm-player-pattern-select"
-                  >
-                    <For each={currentMetadata().patternCandidates ?? []}>
-                      {(candidate) => (
-                        <option value={candidate.id}>
-                          {getPatternOptionLabel(candidate)}
-                        </option>
-                      )}
-                    </For>
-                  </select>
-                </label>
-              </Show>
+              <div class="flex flex-wrap items-center gap-2 md:gap-3">
+                <Show when={patternCandidates().length > 1}>
+                  <label class="flex min-w-[18rem] flex-1 items-center gap-3 text-sm text-slate-600 dark:text-slate-300">
+                    <span class="shrink-0 font-medium text-slate-900 dark:text-slate-100">
+                      Pattern:
+                    </span>
+                    <select
+                      value={currentPatternChoiceId()}
+                      onChange={(event) => {
+                        handlePatternSelectionChange(event.currentTarget.value);
+                      }}
+                      disabled={isPatternLoading()}
+                      class="min-h-11 w-full max-w-[20rem] rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:cursor-not-allowed disabled:bg-slate-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:disabled:bg-slate-900"
+                      data-testid="rhythm-player-pattern-select"
+                    >
+                      <For each={currentMetadata().patternCandidates ?? []}>
+                        {(candidate) => (
+                          <option
+                            value={candidate.id}
+                            selected={candidate.id === currentPatternChoiceId()}
+                          >
+                            {getPatternOptionLabel(candidate)}
+                          </option>
+                        )}
+                      </For>
+                    </select>
+                  </label>
+                </Show>
 
-              <div class="flex flex-wrap items-center gap-2">
                 <Show when={canManageCustomPatterns()}>
                   <Button
                     type="button"
@@ -1884,7 +2077,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                     data-testid="rhythm-player-custom-pattern-open-button"
                   >
                     <Plus class="h-4 w-4" />
-                    New custom pattern
+                    New Custom Pattern
                   </Button>
 
                   <Show when={selectedEditablePatternId()}>
@@ -2091,6 +2284,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                   <AbcNotation
                     notation={displayAbc() ?? ""}
                     class="h-full w-full"
+                    scale={0.62}
                   />
                 </div>
               </div>

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -1276,14 +1276,9 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   });
 
   const playbackAbc = createMemo(() => {
-    const patternType = metadata()?.patternType ?? "seed";
-
-    if (patternType === "seed") {
-      return expandedAbc();
-    }
-
     return expandedAbc();
   });
+
   const selectedPlaybackStartAbc = createMemo(() =>
     rotatePlaybackRhythmAbc(
       playbackAbc(),
@@ -2053,9 +2048,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                     >
                       <For each={currentMetadata().patternCandidates ?? []}>
                         {(candidate) => (
-                          <option
-                            value={candidate.id}
-                          >
+                          <option value={candidate.id}>
                             {getPatternOptionLabel(candidate)}
                           </option>
                         )}

--- a/src/components/rhythm/rhythm-player.css
+++ b/src/components/rhythm/rhythm-player.css
@@ -55,5 +55,10 @@
 }
 
 .rhythm-player-notation svg {
+  display: block;
   height: auto;
+}
+
+.rhythm-player-notation [data-testid="abc-notation-container"] {
+  overflow-x: hidden;
 }

--- a/src/components/tunes/AbcNotation.tsx
+++ b/src/components/tunes/AbcNotation.tsx
@@ -7,6 +7,8 @@ interface AbcNotationProps {
   notation: string;
   /** Whether to resize responsively */
   responsive?: boolean;
+  /** abcjs render scale */
+  scale?: number;
   /** Custom class name for container */
   class?: string;
   /** Show error messages */
@@ -45,6 +47,7 @@ export const AbcNotation: Component<AbcNotationProps> = (props) => {
           // This is the magic bullet for modals. It tells the SVG to fluidly
           // stretch/shrink to fill the container instead of locking to a hardcoded width.
           responsive: "resize",
+          scale: props.scale,
 
           // Adds helpful CSS classes to the SVG elements (staff, notes, etc.)
           // in case you want to style them with Tailwind later.

--- a/src/components/ui/charts.tsx
+++ b/src/components/ui/charts.tsx
@@ -334,8 +334,8 @@ const ScatterChart = /* #__PURE__ */ createTypedChart("scatter", [
 ]);
 
 export {
-  BaseChart as Chart,
   BarChart,
+  BaseChart as Chart,
   BubbleChart,
   DonutChart,
   LineChart,

--- a/src/lib/auth/TTAuthProvider.tsx
+++ b/src/lib/auth/TTAuthProvider.tsx
@@ -853,7 +853,7 @@ const TTInner: ParentComponent = (props) => {
     });
 
     // E2E-only: expose sync control surface for Playwright
-    if (typeof window !== "undefined" && !!(window as any).__ttTestApi) {
+    if (typeof window !== "undefined" && (window as any).__ttTestApi) {
       (window as any).__ttSyncControl = {
         stop: async () => {
           try {

--- a/src/lib/db/client-sqlite.ts
+++ b/src/lib/db/client-sqlite.ts
@@ -38,7 +38,7 @@ export const browserSqliteClient = createBrowserSqliteClient({
     outboxBackupKeyPrefix: "tunetrees-outbox-backup",
     lastSyncTimestampKeyPrefix: "TT_LAST_SYNC_TIMESTAMP",
   },
-  databaseVersion: 24,
+  databaseVersion: 22,
   schemaVersion: "2.0.15-refresh-public-rhythm-patterns",
   migrationFiles: [
     "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",

--- a/src/lib/db/client-sqlite.ts
+++ b/src/lib/db/client-sqlite.ts
@@ -38,8 +38,8 @@ export const browserSqliteClient = createBrowserSqliteClient({
     outboxBackupKeyPrefix: "tunetrees-outbox-backup",
     lastSyncTimestampKeyPrefix: "TT_LAST_SYNC_TIMESTAMP",
   },
-  databaseVersion: 22,
-  schemaVersion: "2.0.13-fix-sync-change-log-coverage",
+  databaseVersion: 24,
+  schemaVersion: "2.0.15-refresh-public-rhythm-patterns",
   migrationFiles: [
     "/drizzle/migrations/sqlite/0000_lowly_obadiah_stane.sql",
     "/drizzle/migrations/sqlite/0001_thin_chronomancer.sql",

--- a/src/lib/db/migration-version.test.ts
+++ b/src/lib/db/migration-version.test.ts
@@ -1,0 +1,132 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLocalDatabaseForMigration,
+  setLocalSchemaVersion,
+} from "./migration-version";
+
+describe("clearLocalDatabaseForMigration", () => {
+  beforeEach(() => {
+    const storage = new Map<string, string>();
+
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+    });
+  });
+
+  afterEach(() => {
+    localStorage.removeItem("schema_version");
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes only public rhythm_patterns rows for the stale catalog migration", async () => {
+    const sqlite = new Database(":memory:");
+
+    sqlite.exec(`
+      CREATE TABLE rhythm_patterns (
+        id TEXT PRIMARY KEY NOT NULL,
+        genre_id TEXT,
+        tune_type_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        part_target TEXT DEFAULT '*',
+        abc_string TEXT NOT NULL,
+        is_default INTEGER NOT NULL DEFAULT 0,
+        premium_audio_url TEXT,
+        sample_kit TEXT NOT NULL DEFAULT 'bodhran',
+        tune_id TEXT,
+        user_id TEXT,
+        pattern_type TEXT NOT NULL DEFAULT 'seed'
+      );
+
+      INSERT INTO rhythm_patterns (
+        id,
+        genre_id,
+        tune_type_id,
+        name,
+        part_target,
+        abc_string,
+        is_default,
+        premium_audio_url,
+        sample_kit,
+        tune_id,
+        user_id,
+        pattern_type
+      ) VALUES
+        (
+          'public-system-default',
+          'ITRAD',
+          'JigD',
+          'Standard Double Jig',
+          '*',
+          'M:6/8\nL:1/8\nK:clef=perc\n|: C2c Ccc :|',
+          1,
+          NULL,
+          'bodhran',
+          NULL,
+          NULL,
+          'seed'
+        ),
+        (
+          'public-tune-override',
+          'ITRAD',
+          'JigD',
+          'Tune Override',
+          '*',
+          'X:1\nT:Tobin''s\nM:6/8\nL:1/8\nK:Dmaj\n|:DFA dcd:|',
+          0,
+          NULL,
+          'bodhran',
+          'tune-1',
+          NULL,
+          'full_track'
+        ),
+        (
+          'user-default',
+          'ITRAD',
+          'JigD',
+          'Plain Taps',
+          '*',
+          'M:6/8\nL:1/8\nK:clef=perc\n|: C2 c C c c :|',
+          0,
+          NULL,
+          'generic_click',
+          NULL,
+          'user-1',
+          'seed'
+        );
+    `);
+
+    setLocalSchemaVersion("2.0.13-fix-sync-change-log-coverage");
+
+    await clearLocalDatabaseForMigration(
+      {},
+      {
+        rawDb: {
+          run: (sql: string) => sqlite.exec(sql),
+        },
+      }
+    );
+
+    const rows = sqlite
+      .prepare("SELECT id, user_id, tune_id FROM rhythm_patterns ORDER BY id")
+      .all() as Array<{
+      id: string;
+      user_id: string | null;
+      tune_id: string | null;
+    }>;
+
+    expect(rows).toEqual([
+      {
+        id: "user-default",
+        user_id: "user-1",
+        tune_id: null,
+      },
+    ]);
+  });
+});

--- a/src/lib/db/migration-version.ts
+++ b/src/lib/db/migration-version.ts
@@ -8,7 +8,20 @@
  * @module lib/db/migration-version
  */
 
-const CURRENT_SCHEMA_VERSION = "2.0.13-fix-sync-change-log-coverage"; // Bump this when schema changes
+const CURRENT_SCHEMA_VERSION = "2.0.15-refresh-public-rhythm-patterns"; // Bump this when stale public rhythm catalog rows must be re-pulled without dropping user-owned data
+
+const TARGETED_PUBLIC_RHYTHM_PATTERN_REFRESH_VERSIONS = new Set([
+  "2.0.13-fix-sync-change-log-coverage",
+  "2.0.14-reset-stale-rhythm-catalog",
+]);
+
+function shouldRefreshPublicRhythmPatternsOnly(
+  localVersion: string | null
+): boolean {
+  return TARGETED_PUBLIC_RHYTHM_PATTERN_REFRESH_VERSIONS.has(
+    localVersion ?? ""
+  );
+}
 
 /**
  * Get the locally stored schema version from localStorage
@@ -108,6 +121,22 @@ export async function clearLocalDatabaseForMigration(
   }
 ): Promise<void> {
   console.log("🔄 Schema migration detected - clearing local database...");
+
+  const localVersion = getLocalSchemaVersion();
+
+  if (shouldRefreshPublicRhythmPatternsOnly(localVersion) && context?.rawDb) {
+    console.log(
+      "🔄 Refreshing public rhythm_patterns rows while preserving user-owned local rows..."
+    );
+
+    context.rawDb.run(`
+      DELETE FROM rhythm_patterns
+      WHERE user_id IS NULL OR TRIM(user_id) = ''
+    `);
+
+    console.log("✅ Public rhythm_patterns rows cleared for targeted refresh");
+    return;
+  }
 
   const drizzleDb = db as {
     delete: <TTable>(table: TTable) => { run: () => unknown };

--- a/src/lib/services/practice-queue.ts
+++ b/src/lib/services/practice-queue.ts
@@ -32,8 +32,8 @@ import {
 } from "../utils/scheduling-windows";
 import { generateId } from "../utils/uuid";
 
-export { classifyQueueBucket, computeSchedulingWindows };
 export type { SchedulingWindows };
+export { classifyQueueBucket, computeSchedulingWindows };
 
 type QueueCandidateRow = Pick<
   PracticeListStagedRow,

--- a/src/lib/services/practice-recording.ts
+++ b/src/lib/services/practice-recording.ts
@@ -784,7 +784,7 @@ export async function commitStagedEvaluations(
         LIMIT 1
       `);
 
-      if (!verifyQueue || !verifyQueue.completed_at) {
+      if (!verifyQueue?.completed_at) {
         console.error(
           `❌ CRITICAL: completed_at NOT SET for tune ${staged.tune_id}!`,
           {

--- a/src/test/test-api.ts
+++ b/src/test/test-api.ts
@@ -14,6 +14,7 @@ import {
   type SqliteDatabase,
 } from "@/lib/db/client-sqlite";
 import { createGroup } from "@/lib/db/queries/groups";
+import { getMediaAssetByReferenceId } from "@/lib/db/queries/media-assets";
 import {
   addTuneSetToSetlist,
   addTuneToSetlist,
@@ -983,6 +984,19 @@ async function getLocalRecord(
 }
 
 /**
+ * Read the regionsJson column from a media_asset by its reference_ref.
+ * Uses the app's already-initialized DB instance (avoids Vite dynamic-import
+ * pitfalls where `getDb()` would see a null drizzleDb in a fresh module closure).
+ */
+async function readMediaAssetRegions(
+  referenceRef: string
+): Promise<string | null> {
+  const db = await ensureDb();
+  const mediaAsset = await getMediaAssetByReferenceId(db, referenceRef);
+  return mediaAsset?.regionsJson ?? null;
+}
+
+/**
  * Get currently selected genres for the user
  */
 async function getSelectedGenres(): Promise<string[]> {
@@ -1357,6 +1371,7 @@ declare global {
         table: string,
         recordId: string | number
       ) => Promise<any>;
+      readMediaAssetRegions: (referenceRef: string) => Promise<string | null>;
       getQueueInfo: (repertoireId: string) => Promise<{
         windowStartUtc: string;
         rowCount: number;
@@ -1780,6 +1795,9 @@ if (typeof window !== "undefined") {
       },
       getLocalRecord: async (table: string, recordId: string | number) => {
         return await getLocalRecord(table, recordId);
+      },
+      readMediaAssetRegions: async (referenceRef: string) => {
+        return await readMediaAssetRegions(referenceRef);
       },
       getAnnotationCounts: async (options?: { tuneId?: string }) => {
         const db = await ensureDb();

--- a/tests/fixtures/test-data.ts
+++ b/tests/fixtures/test-data.ts
@@ -33,16 +33,16 @@ import {
 
 // Re-export catalog tune mappings for convenience
 export {
-  CATALOG_TUNE_ID_MAP,
-  getCatalogTuneUuid,
   CATALOG_TUNE_43_ID,
   CATALOG_TUNE_54_ID,
   CATALOG_TUNE_55_ID,
   CATALOG_TUNE_66_ID,
   CATALOG_TUNE_70_ID,
   CATALOG_TUNE_72_ID,
+  CATALOG_TUNE_ID_MAP,
   CATALOG_TUNE_MORRISON_ID,
   type CatalogTuneId,
+  getCatalogTuneUuid,
 };
 
 // Alias for backwards compatibility with existing tests


### PR DESCRIPTION
## Summary

Fixes #647.

Related to #607.

This branch improves rhythm accompaniment rendering for compact/full-ABC layouts, adds a targeted schema-version refresh for stale public rhythm pattern rows, hardens a few E2E flows, and closes the loop on generated-file handling by regenerating the SQLite client wrapper and strengthening generated-file guardrails.

## What changed

- Improved `RhythmPlayer` handling for compact/repeated-section ABC notation
- Fixed structured notehead resolution and part-label mapping when display lines do not match collapsed structure sections
- Added `scale` support to ABC rendering and tightened rhythm notation layout styling
- Added a targeted schema-version migration path to refresh public `rhythm_patterns` rows while preserving user-owned local rows
- Added regression coverage for the migration-version behavior
- Improved E2E reliability for sync completion, flashcard evaluation targeting, and audio waveform persistence
- Replaced the audio persistence test’s dynamic DB import with a stable test API helper
- Regenerated the SQLite client wrapper so generated output matches codegen source of truth
- Strengthened repo guardrails so generated files are treated as a hard no-edit boundary and schema changes explicitly include `npm run codegen:schema:check`

## Why

- The rhythm player needed to correctly map playback state onto compact ABC displays where repeated structure parts share rendered lines
- The stale public rhythm pattern catalog needed a refresh path that did not wipe user-owned local patterns
- The branch had a generated-file regression in the SQLite client wrapper, so this PR also restores generator-consistent output and makes that class of mistake harder to repeat

## Validation

- `npm run lint`
- `npm run check`
- `npm run typecheck`
- `npm run codegen:schema:check`
- `npm run test:unit`