### PR TITLE
 ✨ Add metronome modes to rhythm player

### DIFF
--- a/src/components/rhythm/RhythmPlayer.test.tsx
+++ b/src/components/rhythm/RhythmPlayer.test.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/lib/rhythm/structured-display-sync";
 import { getStructuredSectionLabel } from "@/lib/rhythm/structured-playback-model";
 import type {
-  MetronomeMode,
   PlaybackEventMarker,
   RhythmPatternMetadata,
   RhythmService,
@@ -33,6 +32,7 @@ const mocked = vi.hoisted(() => {
   const parseOnlyMock = vi.fn(() => [{}]);
   const loadPatternMock = vi.fn<RhythmService["loadPattern"]>(async () => null);
   const updateRhythmAbcMock = vi.fn<RhythmService["updateRhythmAbc"]>();
+  const defaultMetronomeMode: RhythmService["metronomeMode"] = () => "off";
   const buildEditableRhythmPattern = (
     overrides: Partial<EditableRhythmPattern> = {}
   ): EditableRhythmPattern => ({
@@ -88,7 +88,7 @@ const mocked = vi.hoisted(() => {
       metadata: () => null as RhythmPatternMetadata | null,
       tempoQpm: () => 100,
       swingPercentage: () => 0,
-      metronomeMode: () => "off" as MetronomeMode,
+      metronomeMode: defaultMetronomeMode,
       isPlaying: (): boolean => false,
       isPaused: (): boolean => false,
       isReady: () => false,
@@ -234,7 +234,7 @@ describe("RhythmPlayer", () => {
     mocked.serviceStub.metadata = () => null;
     mocked.serviceStub.tempoQpm = () => 100;
     mocked.serviceStub.swingPercentage = () => 0;
-    mocked.serviceStub.metronomeMode = () => "off" as MetronomeMode;
+    mocked.serviceStub.metronomeMode = () => "off";
     mocked.serviceStub.isPlaying = () => false;
     mocked.serviceStub.isPaused = () => false;
     mocked.serviceStub.isCountIn = () => false;

--- a/src/components/rhythm/RhythmPlayer.test.tsx
+++ b/src/components/rhythm/RhythmPlayer.test.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/rhythm/structured-display-sync";
 import { getStructuredSectionLabel } from "@/lib/rhythm/structured-playback-model";
 import type {
+  MetronomeMode,
   PlaybackEventMarker,
   RhythmPatternMetadata,
   RhythmService,
@@ -87,6 +88,7 @@ const mocked = vi.hoisted(() => {
       metadata: () => null as RhythmPatternMetadata | null,
       tempoQpm: () => 100,
       swingPercentage: () => 0,
+      metronomeMode: () => "off" as MetronomeMode,
       isPlaying: (): boolean => false,
       isPaused: (): boolean => false,
       isReady: () => false,
@@ -109,6 +111,7 @@ const mocked = vi.hoisted(() => {
       resetTempoToDefault: vi.fn(async () => undefined),
       setSwingPercentage: vi.fn(async () => undefined),
       resetSwingToDefault: vi.fn(async () => undefined),
+      setMetronomeMode: vi.fn(),
       updateRhythmAbc: updateRhythmAbcMock,
     } satisfies RhythmService,
   };
@@ -231,6 +234,7 @@ describe("RhythmPlayer", () => {
     mocked.serviceStub.metadata = () => null;
     mocked.serviceStub.tempoQpm = () => 100;
     mocked.serviceStub.swingPercentage = () => 0;
+    mocked.serviceStub.metronomeMode = () => "off" as MetronomeMode;
     mocked.serviceStub.isPlaying = () => false;
     mocked.serviceStub.isPaused = () => false;
     mocked.serviceStub.isCountIn = () => false;
@@ -245,6 +249,7 @@ describe("RhythmPlayer", () => {
     mocked.serviceStub.resetTempoToDefault = vi.fn(async () => undefined);
     mocked.serviceStub.setSwingPercentage = vi.fn(async () => undefined);
     mocked.serviceStub.resetSwingToDefault = vi.fn(async () => undefined);
+    mocked.serviceStub.setMetronomeMode = vi.fn();
   });
 
   afterEach(() => {
@@ -3189,6 +3194,66 @@ describe("RhythmPlayer", () => {
     expect(mocked.serviceStub.setSwingPercentage).not.toHaveBeenCalled();
   });
 
+  it("renders metronome mode selector and updates the service selection", async () => {
+    mocked.loadPatternMock.mockResolvedValue({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: "X:1\nM:4/4\nL:1/8\nK:clef=perc\n|: C2 z2 C2 z2 :|",
+      rhythmSignature: "4/4",
+      patternType: "seed",
+      tempoQpm: 112,
+      swingPercentage: 0,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns",
+    });
+    mocked.serviceStub.metadata = () => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: "X:1\nM:4/4\nL:1/8\nK:clef=perc\n|: C2 z2 C2 z2 :|",
+      rhythmSignature: "4/4",
+      patternType: "seed" as const,
+      tempoQpm: 112,
+      swingPercentage: 0,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+    });
+    mocked.serviceStub.metronomeMode = () => "on";
+
+    render(() => <RhythmPlayer tuneTypeName="Reel" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rhythm-player-metronome-mode")).toBeTruthy();
+    });
+
+    const metronomeSelect = screen.getByTestId(
+      "rhythm-player-metronome-select"
+    ) as HTMLSelectElement;
+    expect(metronomeSelect.value).toBe("on");
+    expect(
+      Array.from(metronomeSelect.options).map((option) => option.textContent)
+    ).toEqual(["Off", "On", "Metronome-only"]);
+
+    fireEvent.change(metronomeSelect, {
+      target: { value: "off" },
+    });
+    fireEvent.change(metronomeSelect, {
+      target: { value: "metronome-only" },
+    });
+
+    expect(mocked.serviceStub.setMetronomeMode).toHaveBeenCalledWith("off");
+    expect(mocked.serviceStub.setMetronomeMode).toHaveBeenCalledWith(
+      "metronome-only"
+    );
+  });
+
   it("renders compact preference controls in the mobile overflow menu", async () => {
     Object.defineProperty(globalThis, "matchMedia", {
       writable: true,
@@ -3247,6 +3312,8 @@ describe("RhythmPlayer", () => {
 
     expect(screen.getByTestId("rhythm-player-tempo-reset")).toBeTruthy();
     expect(screen.getByTestId("rhythm-player-swing-reset")).toBeTruthy();
+    expect(screen.getByTestId("rhythm-player-metronome-mode")).toBeTruthy();
+    expect(screen.getByTestId("rhythm-player-metronome-select")).toBeTruthy();
 
     fireEvent.input(screen.getByTestId("rhythm-player-swing-input"), {
       target: { value: "21" },

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -45,6 +45,7 @@ import {
 import { getStructuredSectionLabel } from "@/lib/rhythm/structured-playback-model";
 import { getDefaultSwingPercentage } from "@/lib/services/rhythm-service/playback-helpers";
 import type {
+  MetronomeMode,
   RhythmPatternMetadata,
   RhythmPatternType,
 } from "@/lib/services/rhythm-service/RhythmService";
@@ -100,6 +101,14 @@ const CUSTOM_PATTERN_SCOPE_OPTIONS = {
   user_default: "All tunes of this type",
   user_tune: "This tune only",
 } as const;
+const METRONOME_MODE_OPTIONS: Array<{
+  value: MetronomeMode;
+  label: string;
+}> = [
+  { value: "off", label: "Off" },
+  { value: "on", label: "On" },
+  { value: "metronome-only", label: "Metronome-only" },
+];
 
 function getBeatNoteTargets(container: HTMLDivElement): SVGElement[] {
   return Array.from(container.querySelectorAll<SVGElement>(".abcjs-notehead"));
@@ -296,6 +305,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
       activePatternMetadata()?.swingPercentage ??
       0
   );
+  const metronomeMode = createMemo(() => service()?.metronomeMode() ?? "off");
   const defaultSwingPercentage = createMemo(() =>
     clampSwingPercentage(getDefaultSwingPercentage(activePatternMetadata()))
   );
@@ -901,6 +911,38 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     );
   };
 
+  const metronomeControls = () => {
+    const controlsDisabled =
+      !service() || !activePatternMetadata() || isPatternLoading();
+
+    return (
+      <div
+        class="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300"
+        data-testid="rhythm-player-metronome-mode"
+      >
+        <span class="font-medium text-slate-900 dark:text-slate-100">
+          Metronome
+        </span>
+        <select
+          value={metronomeMode()}
+          disabled={controlsDisabled}
+          class="ml-auto min-h-10 min-w-[11rem] rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition-colors focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+          data-testid="rhythm-player-metronome-select"
+          aria-label="Metronome mode"
+          onChange={(event) => {
+            service()?.setMetronomeMode(
+              event.currentTarget.value as MetronomeMode
+            );
+          }}
+        >
+          <For each={METRONOME_MODE_OPTIONS}>
+            {(option) => <option value={option.value}>{option.label}</option>}
+          </For>
+        </select>
+      </div>
+    );
+  };
+
   const getNotationContainer = (): HTMLDivElement | null => {
     const host = notationHostRef();
     if (!host) {
@@ -1163,6 +1205,10 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                         <div class="h-px bg-slate-200 dark:bg-slate-800" />
 
                         {swingControls()}
+
+                        <div class="h-px bg-slate-200 dark:bg-slate-800" />
+
+                        {metronomeControls()}
                       </div>
                     </DropdownMenu.Content>
                   </DropdownMenu.Portal>
@@ -1335,6 +1381,8 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                   {tempoControls()}
 
                   {swingControls()}
+
+                  {metronomeControls()}
                 </div>
               </Show>
             </div>

--- a/src/lib/services/rhythm-service/RhythmService.test.ts
+++ b/src/lib/services/rhythm-service/RhythmService.test.ts
@@ -963,6 +963,307 @@ describe("createRhythmService", () => {
     dispose();
   });
 
+  it("defaults metronome mode to off", () => {
+    const db = createSampleKitRhythmDb();
+
+    let dispose = () => {};
+    const service = createRoot((nextDispose) => {
+      dispose = nextDispose;
+      return createRhythmService({
+        db,
+        sampleBaseUrl: "",
+      });
+    });
+
+    expect(service.metronomeMode()).toBe("off");
+
+    service.setMetronomeMode("on");
+    expect(service.metronomeMode()).toBe("on");
+
+    dispose();
+  });
+
+  it("mixes metronome clicks with rhythm samples when metronome mode is on", async () => {
+    const db = createSampleKitRhythmDb();
+    const fetchMock = vi.fn(async (_url: string) => ({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(16),
+    }));
+
+    const bufferSources: Array<{
+      buffer: AudioBuffer | null;
+      start: ReturnType<typeof vi.fn>;
+    }> = [];
+
+    class FakeAudioContext {
+      state: AudioContextState = "running";
+      currentTime = 0;
+      sampleRate = 44_100;
+      destination = {};
+      resume = vi.fn(async () => undefined);
+      decodeAudioData = vi.fn(async () => ({
+        duration: 0.25,
+        length: 1,
+        numberOfChannels: 1,
+        sampleRate: 44_100,
+      })) as unknown as typeof AudioContext.prototype.decodeAudioData;
+      createBuffer = vi.fn(
+        (_channels: number, length: number, sampleRate: number) => {
+          const data = new Float32Array(length);
+          return {
+            duration: length / sampleRate,
+            length,
+            numberOfChannels: 1,
+            sampleRate,
+            getChannelData: vi.fn(() => data),
+          } as unknown as AudioBuffer;
+        }
+      );
+      createBufferSource = vi.fn(() => {
+        const source = {
+          buffer: null as AudioBuffer | null,
+          connect: vi.fn(),
+          start: vi.fn(),
+        };
+        bufferSources.push(source);
+        return source as unknown as AudioBufferSourceNode;
+      });
+      createGain = vi.fn(
+        () =>
+          ({
+            gain: { value: 1 },
+            connect: vi.fn(),
+          }) as unknown as GainNode
+      );
+      close = vi.fn(async () => undefined);
+    }
+
+    class FakeTimingCallbacks {
+      readonly options: {
+        qpm?: number;
+        beatCallback?: (beatNumber: number) => void;
+        eventCallback?: (event: {
+          type: "event";
+          measureStart: boolean;
+          measureNumber: number;
+          milliseconds: number;
+          millisecondsPerMeasure: number;
+          midiPitches: Array<{ pitch: number }>;
+          elements: HTMLElement[][];
+        }) => void;
+      };
+
+      constructor(
+        _visualObj: unknown,
+        options: FakeTimingCallbacks["options"]
+      ) {
+        this.options = options;
+      }
+
+      start() {
+        this.options.beatCallback?.(1);
+        this.options.beatCallback?.(2);
+        this.options.eventCallback?.({
+          type: "event",
+          measureStart: true,
+          measureNumber: 1,
+          milliseconds: 0,
+          millisecondsPerMeasure: 2000,
+          midiPitches: [{ pitch: 60 }],
+          elements: [[]],
+        });
+      }
+
+      pause() {
+        noop();
+      }
+
+      reset() {
+        noop();
+      }
+
+      stop() {
+        noop();
+      }
+
+      currentMillisecond() {
+        return 0;
+      }
+    }
+
+    const fakeAbcjs = {
+      renderAbc: vi.fn(
+        () => [{}] as unknown as ReturnType<typeof import("abcjs").renderAbc>
+      ),
+      TimingCallbacks:
+        FakeTimingCallbacks as unknown as typeof import("abcjs").TimingCallbacks,
+    };
+
+    let dispose = () => {};
+    const service = createRoot((nextDispose) => {
+      dispose = nextDispose;
+      return createRhythmService({
+        db,
+        abcjsModule: fakeAbcjs,
+        audioContext: new FakeAudioContext() as unknown as AudioContext,
+        sampleBaseUrl: "",
+        fetchImpl: asFetch(fetchMock),
+      });
+    });
+
+    await service.loadPattern({
+      genreName: "Session Test",
+      tuneTypeName: "Reel",
+    });
+    service.setMetronomeMode("on");
+
+    await service.play();
+
+    expect(bufferSources.map((source) => source.buffer?.length)).toEqual(
+      expect.arrayContaining([882, 882, 1])
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(EXPECTED_BODHRAN_FETCH_COUNT);
+
+    dispose();
+  });
+
+  it("plays metronome-only clicks without samples or premium loops", async () => {
+    const db = createPremiumLoopRhythmDb();
+    const fetchMock = vi.fn(async (_url: string) => ({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(16),
+    }));
+    const premiumPlay = vi.fn(async () => undefined);
+    const bufferSources: Array<{
+      buffer: AudioBuffer | null;
+      start: ReturnType<typeof vi.fn>;
+    }> = [];
+
+    class FakeAudioContext {
+      state: AudioContextState = "running";
+      currentTime = 0;
+      sampleRate = 44_100;
+      destination = {};
+      resume = vi.fn(async () => undefined);
+      decodeAudioData = vi.fn(async () => ({
+        duration: 0.25,
+        length: 1,
+        numberOfChannels: 1,
+        sampleRate: 44_100,
+      })) as unknown as typeof AudioContext.prototype.decodeAudioData;
+      createBuffer = vi.fn(
+        (_channels: number, length: number, sampleRate: number) => {
+          const data = new Float32Array(length);
+          return {
+            duration: length / sampleRate,
+            length,
+            numberOfChannels: 1,
+            sampleRate,
+            getChannelData: vi.fn(() => data),
+          } as unknown as AudioBuffer;
+        }
+      );
+      createBufferSource = vi.fn(() => {
+        const source = {
+          buffer: null as AudioBuffer | null,
+          connect: vi.fn(),
+          start: vi.fn(),
+        };
+        bufferSources.push(source);
+        return source as unknown as AudioBufferSourceNode;
+      });
+      createGain = vi.fn(
+        () =>
+          ({
+            gain: { value: 1 },
+            connect: vi.fn(),
+          }) as unknown as GainNode
+      );
+      close = vi.fn(async () => undefined);
+    }
+
+    class FakeTimingCallbacks {
+      readonly options: {
+        beatCallback?: (beatNumber: number) => void;
+      };
+
+      constructor(
+        _visualObj: unknown,
+        options: FakeTimingCallbacks["options"]
+      ) {
+        this.options = options;
+      }
+
+      start() {
+        this.options.beatCallback?.(1);
+        this.options.beatCallback?.(2);
+      }
+
+      pause() {
+        noop();
+      }
+
+      reset() {
+        noop();
+      }
+
+      stop() {
+        noop();
+      }
+
+      currentMillisecond() {
+        return 0;
+      }
+    }
+
+    const fakeAbcjs = {
+      renderAbc: vi.fn(
+        () => [{}] as unknown as ReturnType<typeof import("abcjs").renderAbc>
+      ),
+      TimingCallbacks:
+        FakeTimingCallbacks as unknown as typeof import("abcjs").TimingCallbacks,
+    };
+
+    let dispose = () => {};
+    const service = createRoot((nextDispose) => {
+      dispose = nextDispose;
+      return createRhythmService({
+        db,
+        abcjsModule: fakeAbcjs,
+        audioContext: new FakeAudioContext() as unknown as AudioContext,
+        audioElementFactory: () => ({
+          crossOrigin: "",
+          currentTime: 0,
+          loop: false,
+          pause: vi.fn(),
+          play: premiumPlay,
+          playbackRate: 1,
+          preload: "",
+          src: "",
+        }),
+        fetchImpl: asFetch(fetchMock),
+        preferPremiumLoop: () => true,
+        sampleBaseUrl: "",
+      });
+    });
+
+    await service.loadPattern({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+    });
+    service.setMetronomeMode("metronome-only");
+
+    await service.play();
+
+    expect(bufferSources.map((source) => source.buffer?.length)).toEqual([
+      882, 882,
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(premiumPlay).not.toHaveBeenCalled();
+
+    dispose();
+  });
+
   it("plays mapped bodhran samples and restarts timing callbacks when tempo changes", async () => {
     const db = createSampleKitRhythmDb();
     const fetchMock = vi.fn(async (_url: string) => ({
@@ -1198,6 +1499,96 @@ describe("createRhythmService", () => {
     });
 
     expect(secondService.tempoQpm()).toBe(136);
+  });
+
+  it("restores the stored metronome mode per user and rhythm type", async () => {
+    const db = createPremiumLoopRhythmDb();
+    vi.stubGlobal("localStorage", createMockStorage());
+
+    const firstService = createRoot(() =>
+      createRhythmService({
+        db,
+      })
+    );
+
+    await firstService.loadPattern({
+      userId: "user-1",
+      tuneTypeName: "Reel",
+    });
+    firstService.setMetronomeMode("metronome-only");
+
+    const secondService = createRoot(() =>
+      createRhythmService({
+        db,
+      })
+    );
+
+    await secondService.loadPattern({
+      userId: "user-1",
+      tuneTypeName: "Reel",
+    });
+
+    expect(secondService.metronomeMode()).toBe("metronome-only");
+  });
+
+  it("keeps stored metronome modes isolated by user", async () => {
+    const db = createPremiumLoopRhythmDb();
+    vi.stubGlobal("localStorage", createMockStorage());
+
+    const firstService = createRoot(() =>
+      createRhythmService({
+        db,
+      })
+    );
+
+    await firstService.loadPattern({
+      userId: "user-1",
+      tuneTypeName: "Reel",
+    });
+    firstService.setMetronomeMode("metronome-only");
+
+    const secondService = createRoot(() =>
+      createRhythmService({
+        db,
+      })
+    );
+
+    await secondService.loadPattern({
+      userId: "user-2",
+      tuneTypeName: "Reel",
+    });
+
+    expect(secondService.metronomeMode()).toBe("off");
+  });
+
+  it("keeps stored metronome modes isolated by rhythm type", async () => {
+    const db = createSampleKitRhythmDb();
+    vi.stubGlobal("localStorage", createMockStorage());
+
+    const firstService = createRoot(() =>
+      createRhythmService({
+        db,
+      })
+    );
+
+    await firstService.loadPattern({
+      userId: "user-1",
+      tuneTypeName: "Reel",
+    });
+    firstService.setMetronomeMode("metronome-only");
+
+    const secondService = createRoot(() =>
+      createRhythmService({
+        db,
+      })
+    );
+
+    await secondService.loadPattern({
+      userId: "user-1",
+      tuneTypeName: "Jig",
+    });
+
+    expect(secondService.metronomeMode()).toBe("off");
   });
 
   it("starts playback from a structured beat and measure offset", async () => {

--- a/src/lib/services/rhythm-service/RhythmService.ts
+++ b/src/lib/services/rhythm-service/RhythmService.ts
@@ -22,6 +22,10 @@ import {
   waitForMilliseconds,
 } from "@/lib/services/rhythm-service/audio-helpers";
 import {
+  readStoredRhythmMetronomeMode,
+  writeStoredRhythmMetronomeMode,
+} from "@/lib/services/rhythm-service/metronome-storage";
+import {
   clampTempo,
   createCountInBuffers,
   eventHasAccent,
@@ -59,6 +63,8 @@ function clampSwingPercentage(value: number): number {
   }
   return Math.min(1, Math.max(0, value));
 }
+
+export type MetronomeMode = "off" | "on" | "metronome-only";
 
 export type {
   RhythmPatternCandidate,
@@ -110,6 +116,7 @@ export interface RhythmService {
   metadata: Accessor<RhythmPatternMetadata | null>;
   tempoQpm: Accessor<number>;
   swingPercentage: Accessor<number>;
+  metronomeMode: Accessor<MetronomeMode>;
   isPlaying: Accessor<boolean>;
   isPaused: Accessor<boolean>;
   isReady: Accessor<boolean>;
@@ -134,6 +141,7 @@ export interface RhythmService {
   resetTempoToDefault: () => Promise<void>;
   setSwingPercentage: (nextSwingPercentage: number) => Promise<void>;
   resetSwingToDefault: () => Promise<void>;
+  setMetronomeMode: (nextMode: MetronomeMode) => void;
   updateRhythmAbc: (nextRhythmAbc: string) => void;
 }
 
@@ -199,6 +207,8 @@ export function createRhythmService(
   );
   const [tempoQpm, setTempoQpmSignal] = createSignal(100);
   const [swingPercentage, setSwingPercentageSignal] = createSignal(0);
+  const [metronomeMode, setMetronomeModeSignal] =
+    createSignal<MetronomeMode>("off");
   const [isPlaying, setIsPlaying] = createSignal(false);
   const [isPaused, setIsPaused] = createSignal(false);
   const [isReady, setIsReady] = createSignal(false);
@@ -218,6 +228,7 @@ export function createRhythmService(
   let pendingStartPlayback: Promise<void> | null = null;
   let ownedAudioContext: AudioContext | null = null;
   let sampleBuffers = new Map<number, AudioBuffer>();
+  let metronomeBuffer: AudioBuffer | null = null;
   let loadedSampleKit: string | null = null;
   let premiumLoopAudio: PremiumLoopAudio | null = null;
   let premiumLoopUrl: string | null = null;
@@ -226,12 +237,17 @@ export function createRhythmService(
   let playbackStartBeatIndex = 0;
   let playbackStartMeasure = 0;
   let activePlaybackRhythmAbc: string | null = null;
+  let lastMetronomeBeatNumber = -1;
   let remainingDebugPlaybackPasses = getRequestedRhythmPlaybackDebugPasses();
   let tempoPreferenceKey: {
     userId: string | null | undefined;
     tuneTypeName: string;
   } | null = null;
   let swingPreferenceKey: {
+    userId: string | null | undefined;
+    tuneTypeName: string;
+  } | null = null;
+  let metronomePreferenceKey: {
     userId: string | null | undefined;
     tuneTypeName: string;
   } | null = null;
@@ -454,6 +470,48 @@ export function createRhythmService(
     setIsReady(true);
   }
 
+  async function ensureMetronomeBuffersLoaded(): Promise<void> {
+    if (metronomeBuffer) {
+      setIsReady(true);
+      return;
+    }
+
+    const audioContext = await ensureAudioContext();
+    metronomeBuffer =
+      createCountInBuffers((entry) =>
+        createSyntheticClickBuffer(audioContext, entry)
+      )?.secondaryBuffer ?? null;
+    setIsReady(true);
+  }
+
+  function playMetronomePulse(
+    beatNumber: number,
+    audioContext: AudioContext
+  ): void {
+    if (metronomeMode() === "off" || !metronomeBuffer) {
+      return;
+    }
+
+    const normalizedBeatNumber = Math.floor(beatNumber);
+    if (
+      !Number.isFinite(normalizedBeatNumber) ||
+      normalizedBeatNumber < 0 ||
+      normalizedBeatNumber === lastMetronomeBeatNumber
+    ) {
+      return;
+    }
+    lastMetronomeBeatNumber = normalizedBeatNumber;
+
+    const source = audioContext.createBufferSource();
+    const gainNode = audioContext.createGain();
+
+    source.buffer = metronomeBuffer;
+    gainNode.gain.value = 0.72;
+    source.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+    source.start();
+  }
+
   function playEventPitches(
     event: NoteTimingEvent,
     audioContext: AudioContext
@@ -565,7 +623,8 @@ export function createRhythmService(
   function buildTimingCallbacks(
     rhythmAbc: string,
     audioContext: AudioContext,
-    shouldPlayEventSamples: boolean
+    shouldPlayEventSamples: boolean,
+    shouldPlayMetronome: boolean
   ): TimingCallbacksInstance {
     if (typeof document === "undefined") {
       throw new TypeError("ABC rhythm playback requires a browser document.");
@@ -584,6 +643,9 @@ export function createRhythmService(
 
     const beatCallback: BeatCallback = (beatNumber) => {
       setCurrentPulse(Math.max(0, Math.floor(beatNumber)));
+      if (shouldPlayMetronome) {
+        playMetronomePulse(beatNumber, audioContext);
+      }
     };
 
     const animationOptions: AnimationOptions = {
@@ -667,9 +729,20 @@ export function createRhythmService(
     setCurrentPulse(0);
     setIsPaused(false);
     setCurrentMeasure(playbackStartMeasure);
+    lastMetronomeBeatNumber = -1;
 
-    if (!resolvePremiumLoopSelection(currentMetadata)) {
+    const currentMetronomeMode = metronomeMode();
+    const shouldSuppressRhythmAudio = currentMetronomeMode === "metronome-only";
+    const shouldPlayMetronome = currentMetronomeMode !== "off";
+    const premiumLoopSelection = shouldSuppressRhythmAudio
+      ? null
+      : resolvePremiumLoopSelection(currentMetadata);
+
+    if (!shouldSuppressRhythmAudio && !premiumLoopSelection) {
       await ensureSamplesLoaded();
+    }
+    if (shouldPlayMetronome) {
+      await ensureMetronomeBuffersLoaded();
     }
 
     const audioContext = await ensureAudioContext();
@@ -686,7 +759,6 @@ export function createRhythmService(
     }
 
     let usingPremiumLoop = false;
-    const premiumLoopSelection = resolvePremiumLoopSelection(currentMetadata);
     if (premiumLoopSelection) {
       try {
         await startPremiumLoopAudio(
@@ -702,7 +774,11 @@ export function createRhythmService(
         stopPremiumLoopAudio(true);
       }
     }
-    if (!usingPremiumLoop && sampleBuffers.size === 0) {
+    if (
+      !shouldSuppressRhythmAudio &&
+      !usingPremiumLoop &&
+      sampleBuffers.size === 0
+    ) {
       await ensureSamplesLoaded();
     }
 
@@ -710,7 +786,8 @@ export function createRhythmService(
     timingCallbacks = buildTimingCallbacks(
       activePlaybackRhythmAbc || currentMetadata.rhythmAbc,
       audioContext,
-      !usingPremiumLoop
+      !shouldSuppressRhythmAudio && !usingPremiumLoop,
+      shouldPlayMetronome
     );
     timingCallbacks.start(
       positionMs == null ? undefined : msToSeconds(positionMs),
@@ -747,6 +824,7 @@ export function createRhythmService(
     stopPlayback();
     tempoPreferenceKey = null;
     swingPreferenceKey = null;
+    metronomePreferenceKey = null;
     lastKnownPositionMs = 0;
     resetCountInState();
     setCurrentBeatIndex(0);
@@ -768,6 +846,10 @@ export function createRhythmService(
         userId: request.userId,
         tuneTypeName: request.tuneTypeName?.trim() || nextMetadata.tuneTypeName,
       };
+      metronomePreferenceKey = {
+        userId: request.userId,
+        tuneTypeName: request.tuneTypeName?.trim() || nextMetadata.tuneTypeName,
+      };
       setTempoQpmSignal(
         readStoredRhythmTempo(
           tempoPreferenceKey.userId,
@@ -779,6 +861,12 @@ export function createRhythmService(
           swingPreferenceKey.userId,
           swingPreferenceKey.tuneTypeName
         ) ?? clampSwingPercentage(getDefaultSwingPercentage(nextMetadata))
+      );
+      setMetronomeModeSignal(
+        readStoredRhythmMetronomeMode(
+          metronomePreferenceKey.userId,
+          metronomePreferenceKey.tuneTypeName
+        ) ?? "off"
       );
       setIsReady(false);
     }
@@ -965,6 +1053,17 @@ export function createRhythmService(
     }
   }
 
+  function setMetronomeMode(nextMode: MetronomeMode): void {
+    setMetronomeModeSignal(nextMode);
+    if (metronomePreferenceKey) {
+      writeStoredRhythmMetronomeMode(
+        metronomePreferenceKey.userId,
+        metronomePreferenceKey.tuneTypeName,
+        nextMode
+      );
+    }
+  }
+
   onCleanup(() => {
     stopPlayback();
     if (ownedAudioContext && ownedAudioContext.state !== "closed") {
@@ -978,6 +1077,7 @@ export function createRhythmService(
     metadata,
     tempoQpm,
     swingPercentage,
+    metronomeMode,
     isPlaying,
     isPaused,
     isReady,
@@ -1053,6 +1153,7 @@ export function createRhythmService(
     resetTempoToDefault,
     setSwingPercentage,
     resetSwingToDefault,
+    setMetronomeMode,
     updateRhythmAbc,
   };
 }

--- a/src/lib/services/rhythm-service/metronome-storage.ts
+++ b/src/lib/services/rhythm-service/metronome-storage.ts
@@ -1,0 +1,72 @@
+import { normalizeTuneTypeName } from "@/lib/rhythm/tune-type-lookup";
+import type { MetronomeMode } from "@/lib/services/rhythm-service/RhythmService";
+
+const RHYTHM_METRONOME_STORAGE_KEY_PREFIX = "tunetrees.rhythm-metronome";
+const METRONOME_MODES = new Set<MetronomeMode>(["off", "on", "metronome-only"]);
+
+function getRhythmMetronomeStorage(): Storage | null {
+  if (typeof globalThis === "undefined") {
+    return null;
+  }
+
+  try {
+    const storage =
+      "localStorage" in globalThis ? globalThis.localStorage : null;
+    if (
+      storage &&
+      typeof storage.getItem === "function" &&
+      typeof storage.setItem === "function"
+    ) {
+      return storage;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function buildRhythmMetronomeStorageKey(
+  userId: string | null | undefined,
+  tuneTypeName: string
+): string {
+  const normalizedUserId = userId?.trim() || "anonymous";
+  return [
+    RHYTHM_METRONOME_STORAGE_KEY_PREFIX,
+    normalizedUserId,
+    normalizeTuneTypeName(tuneTypeName),
+  ].join(":");
+}
+
+export function readStoredRhythmMetronomeMode(
+  userId: string | null | undefined,
+  tuneTypeName: string
+): MetronomeMode | null {
+  const storage = getRhythmMetronomeStorage();
+  if (!storage) {
+    return null;
+  }
+
+  const rawValue = storage.getItem(
+    buildRhythmMetronomeStorageKey(userId, tuneTypeName)
+  );
+  return METRONOME_MODES.has(rawValue as MetronomeMode)
+    ? (rawValue as MetronomeMode)
+    : null;
+}
+
+export function writeStoredRhythmMetronomeMode(
+  userId: string | null | undefined,
+  tuneTypeName: string,
+  metronomeMode: MetronomeMode
+): void {
+  const storage = getRhythmMetronomeStorage();
+  if (!storage) {
+    return;
+  }
+
+  storage.setItem(
+    buildRhythmMetronomeStorageKey(userId, tuneTypeName),
+    metronomeMode
+  );
+}


### PR DESCRIPTION
- Add off/on/metronome-only playback modes to RhythmService
- Schedule an even synthesized metronome click from the existing playback timeline
- Add a compact Rhythm Player metronome dropdown control
- Persist metronome mode in localStorage by user and tune type
- Cover mixed, metronome-only, UI selection, and persistence flows

## Summary

This PR delivers one mergeable slice of #607.

Related to #607.

Note: this PR advances #607 but does not close it.

## Advances #607

- 
- 

## Not in this PR

- 
- 

## Merge safety

This is safe to merge now because:
- 
- 

## Review focus

- 
- 

## Validation

- `npm run lint && npm run check && npm run typecheck && npm run test:unit`
- 

## Notes

- Do not use `Closes #607`, `Fixes #607`, or `Resolves #607` in this PR unless it actually completes the umbrella issue.
- Prefer wording like `Related to #607`, `Part of #607`, or `Advances #607` for incremental PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metronome mode selection in the rhythm player: Off, On (mixed with rhythm), and Metronome-only.
  * Metronome preference persistence per user and tune type; controls are available on desktop and mobile UIs.

* **Tests**
  * Expanded tests covering metronome modes, persistence, UI selector behavior, and mobile menu integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->