### PR TITLE
 ✨  🐛 feat: add hands-free player transport and verify deployed Pages assets

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -56,6 +56,7 @@ PYTHONPATH=.
 
 # Repository name
 GITHUB_REPO=tunetrees
+PRODUCTION_BASE_URL="https://tunetrees.com"
 
 # Sync Worker URL for production builds.
 # Use a production-specific 1Password field so deployed bundles never point to

--- a/.env.staging.template
+++ b/.env.staging.template
@@ -68,7 +68,7 @@ PYTHONPATH=.
 
 # Repository name
 GITHUB_REPO=tunetrees
-STAGING_BASE_URL="https://staging.tunetrees-pwa.pages.dev"
+STAGING_BASE_URL="https://staging.tunetrees.com"
 
 # Sync Worker URL for production builds.
 # Use a production-specific 1Password field so deployed bundles never point to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1032,6 +1032,9 @@ jobs:
               --project-name=tunetrees-pwa \
               --branch=staging
 
+      - name: Verify staging Pages assets through the public hostname
+        run: npm run verify:deployed-pages-assets -- https://staging.tunetrees.com
+
       - name: Install PostgreSQL 17 client
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.skip_staging_data_refresh != 'true' }}
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -230,6 +230,9 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
+      - name: Verify production Pages assets through the public hostname
+        run: npm run verify:deployed-pages-assets -- https://tunetrees.com
+
       - name: Install Playwright browser for production smoke
         run: npx --ignore-scripts playwright@1.60.0 install --with-deps chromium
 

--- a/docs/design/player-transport-controls.md
+++ b/docs/design/player-transport-controls.md
@@ -1,0 +1,36 @@
+# Player Transport Controls
+
+## Purpose
+
+This specification defines the shared transport controls for the Audio Player
+and Rhythm Player, including programmable keyboard-emulating foot pedals.
+
+## Initial control scheme
+
+| Action | Keyboard / pedal mapping | Result |
+| --- | --- | --- |
+| Play / Pause | `,` | Starts playback, pauses active playback, or resumes paused playback. |
+| Play with restart | `.` | Stops any active or paused playback, then starts again from the selected start position. |
+| Stop and rewind | `/` | Stops playback and rewinds; the next start uses the selected start position. |
+
+These controls are local to each mounted player. If both players are open, the
+same pedal command reaches both; synchronized countdown timing is deliberately
+outside this initial transport scope.
+
+## Keyboard safety
+
+- Do not handle a shortcut while focus is in a text-entry control (`input`
+  types that accept text, `textarea`, or `contenteditable`). Checkboxes,
+  selects, sliders, and buttons continue to receive player shortcuts.
+- Ignore auto-repeat presses so a held pedal cannot repeatedly toggle
+  transport.
+- `Escape` keeps its dialog-dismissal behavior. Closing a player also stops
+  its playback.
+
+## Countdown scope
+
+The Rhythm Player currently performs a one-bar audible count-in before a
+fresh start; the Audio Player currently has no countdown. The transport
+contract deliberately preserves those feature-specific behaviors. A future
+countdown design must define duration, visual treatment, audio cues, and how
+two simultaneously-open players synchronize before changing either player.

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -84,8 +84,11 @@ In order, the workflow:
 7. Deploys the production Worker.
 8. Builds the production Pages bundle.
 9. Deploys Cloudflare Pages project `tunetrees-pwa` on branch `main`.
-10. Runs production-safe Playwright smoke tests.
-11. Writes the result to the GitHub job summary.
+10. Verifies every generated JavaScript, CSS, and WASM asset through
+    `https://tunetrees.com`, rejecting non-200 responses or incorrect MIME
+    types before the deployment can be marked successful.
+11. Runs production-safe Playwright smoke tests against the public hostname.
+12. Writes the result to the GitHub job summary.
 
 The workflow does not copy staging database data, staging R2 objects, or staging schema artifacts into production. Production database changes occur only through committed migrations applied by `db:production:schema:push`.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:staging": "tsc -b && FORCE_COLOR=1 op run --env-file=\".env.staging.template\" -- vite build && node scripts/verify-sqlite-wasm-build.js",
     "build:preview-local": "tsc -b && FORCE_COLOR=1 op run --env-file=\".env.local.template\" -- tsx scripts/build-preview-local.ts",
     "verify:sqlite-wasm-build": "node scripts/verify-sqlite-wasm-build.js",
+    "verify:deployed-pages-assets": "node scripts/verify-deployed-pages-assets.mjs",
     "preview": "FORCE_COLOR=1 op run --env-file=\".env.local.template\" -- vite preview",
     "preview:local": "op run --env-file=\".env.local.template\" -- vite preview --strictPort --port 4173",
     "codegen:schema": "op run --env-file=\".env.local.template\" -- tsx node_modules/oosync/src/codegen-schema.ts",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Page not found | TuneTrees</title>
+  </head>
+  <body>
+    <main>
+      <h1>Page not found</h1>
+      <p>The requested resource does not exist.</p>
+      <p><a href="/">Return to TuneTrees</a></p>
+    </main>
+  </body>
+</html>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,19 @@
-/*    /index.html   200
+# Cloudflare Pages applies redirects before serving static files. Keep SPA
+# fallbacks limited to actual client routes so a missing hashed asset returns a
+# 404 instead of being rewritten to index.html with a misleading 200 response.
+/login                         /index.html 200
+/privacy                       /index.html 200
+/terms                         /index.html 200
+/auth/callback                 /index.html 200
+/reset-password                /index.html 200
+/user-settings                 /index.html 200
+/user-settings/*               /index.html 200
+/practice                      /index.html 200
+/practice/history              /index.html 200
+/repertoire                    /index.html 200
+/catalog                       /index.html 200
+/analysis                      /index.html 200
+/setlists                      /index.html 200
+/groups                        /index.html 200
+/debug/db                      /index.html 200
+/tunes/*                       /index.html 200

--- a/scripts/verify-deployed-pages-assets.mjs
+++ b/scripts/verify-deployed-pages-assets.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const baseUrlInput = process.argv[2] ?? process.env.DEPLOYED_PAGES_URL;
+
+if (!baseUrlInput) {
+  console.error(
+    "Usage: node scripts/verify-deployed-pages-assets.mjs <public-pages-url>"
+  );
+  process.exit(1);
+}
+
+let baseUrl;
+try {
+  baseUrl = new URL(baseUrlInput);
+} catch {
+  console.error(`Invalid public Pages URL: ${baseUrlInput}`);
+  process.exit(1);
+}
+
+const assetsDirectory = path.join(process.cwd(), "dist", "assets");
+const contentTypePatterns = {
+  ".css": /text\/css/i,
+  ".js": /(?:text|application)\/(?:javascript|ecmascript)/i,
+  ".wasm": /application\/wasm/i,
+};
+
+let assetNames;
+try {
+  assetNames = await fs.readdir(assetsDirectory);
+} catch {
+  console.error(
+    "Deployed Pages asset verification failed: dist/assets does not exist; run the build first."
+  );
+  process.exit(1);
+}
+
+const assetsToVerify = assetNames.filter((assetName) =>
+  Object.hasOwn(contentTypePatterns, path.extname(assetName))
+);
+
+if (assetsToVerify.length === 0) {
+  console.error(
+    "Deployed Pages asset verification failed: no JavaScript, CSS, or WASM assets were found."
+  );
+  process.exit(1);
+}
+
+const FETCH_TIMEOUT_MS = 15_000;
+const failures = [];
+for (const assetName of assetsToVerify) {
+  const assetUrl = new URL(`/assets/${assetName}`, baseUrl);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(assetUrl, {
+      headers: { Accept: "*/*", "Cache-Control": "no-cache" },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    await response.body?.cancel();
+
+    const expectedContentType = contentTypePatterns[path.extname(assetName)];
+    const contentType = response.headers.get("content-type") ?? "(missing)";
+    if (!response.ok || !expectedContentType.test(contentType)) {
+      failures.push(
+        `${assetUrl.pathname}: ${response.status} ${contentType} (expected ${expectedContentType})`
+      );
+    }
+  } catch (error) {
+    clearTimeout(timer);
+    const message =
+      error.name === "AbortError"
+        ? `timeout after ${FETCH_TIMEOUT_MS}ms`
+        : error.message || String(error);
+    failures.push(`${assetUrl.pathname}: ${message}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Deployed Pages asset verification failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Deployed Pages asset verification passed for ${baseUrl.origin} (${assetsToVerify.length} assets).`
+);

--- a/src/components/audio/WaveformAudioPlayer.tsx
+++ b/src/components/audio/WaveformAudioPlayer.tsx
@@ -5,6 +5,7 @@ import {
   Play,
   Repeat,
   Scissors,
+  Square,
   Trash2,
   X,
 } from "lucide-solid";
@@ -365,6 +366,7 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
   const { session, localDb } = useAuth();
   const [isReady, setIsReady] = createSignal(false);
   const [isPlaying, setIsPlaying] = createSignal(false);
+  const [isPaused, setIsPaused] = createSignal(false);
   const [currentTime, setCurrentTime] = createSignal(0);
   const [duration, setDuration] = createSignal(
     props.track.durationSeconds ?? 0
@@ -408,6 +410,7 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
   let didDragSelectionChange = false;
   let suppressNextRowClick = false;
   let objectUrlToRevoke: string | null = null;
+  let transportWasStopped = false;
 
   type RegionListModifiers = {
     shiftKey: boolean;
@@ -550,10 +553,28 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
   };
 
   const stopPlayback = () => {
+    transportWasStopped = true;
     waveSurfer?.pause();
     audioElement?.pause();
     setIsPlaying(false);
+    setIsPaused(false);
   };
+
+  const stopAndRewind = () => {
+    stopPlayback();
+    waveSurfer?.setTime(0);
+    setCurrentTime(0);
+  };
+
+  const restartPlayback = () => {
+    stopAndRewind();
+    if (loopEnabled() && playSelectedRegion()) {
+      return;
+    }
+    void waveSurfer?.play();
+  };
+
+  const canControlTransport = () => isPlaying() || currentTime() > 0;
 
   const collectSerializedRegions = () => {
     if (!regionsPlugin) {
@@ -774,14 +795,26 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
     }
 
     if (waveSurfer.isPlaying()) {
+      transportWasStopped = false;
       waveSurfer.pause();
+      setIsPaused(true);
+      return;
+    }
+
+    if (isPaused()) {
+      transportWasStopped = false;
+      setIsPaused(false);
+      void waveSurfer.play();
       return;
     }
 
     if (loopEnabled() && playSelectedRegion()) {
+      transportWasStopped = false;
       return;
     }
 
+    transportWasStopped = false;
+    setIsPaused(false);
     void waveSurfer.play();
   };
 
@@ -844,15 +877,6 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
       return;
     }
 
-    applyRegionListSelection(regionId, event);
-  };
-
-  const handleRegionListKeyDown = (regionId: string, event: KeyboardEvent) => {
-    if (event.key !== "Enter" && event.key !== " ") {
-      return;
-    }
-
-    event.preventDefault();
     applyRegionListSelection(regionId, event);
   };
 
@@ -990,13 +1014,85 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
         event.preventDefault();
         addAnnotation("measure");
         break;
-      case "s":
-        event.preventDefault();
-        addAnnotation("section");
-        break;
       default:
         break;
     }
+  };
+
+  const shouldIgnoreTransportHotkeys = (target: EventTarget | null) => {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+
+    const editableTarget = target.closest<HTMLElement>(
+      "input, textarea, [contenteditable='true']"
+    );
+    if (!editableTarget || editableTarget.isContentEditable) {
+      return Boolean(editableTarget?.isContentEditable);
+    }
+
+    if (editableTarget instanceof HTMLTextAreaElement) {
+      return true;
+    }
+
+    if (!(editableTarget instanceof HTMLInputElement)) {
+      return false;
+    }
+
+    return ![
+      "button",
+      "checkbox",
+      "color",
+      "file",
+      "hidden",
+      "radio",
+      "range",
+      "reset",
+      "submit",
+    ].includes(editableTarget.type);
+  };
+
+  const handleTransportHotkeys = (event: KeyboardEvent) => {
+    if (
+      event.defaultPrevented ||
+      event.repeat ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      shouldIgnoreTransportHotkeys(event.target)
+    ) {
+      return;
+    }
+
+    const key = event.key.toLowerCase();
+    if (key === "/") {
+      if (!canControlTransport()) {
+        return;
+      }
+      event.preventDefault();
+      stopAndRewind();
+      return;
+    }
+
+    if (key === ".") {
+      if (!canControlTransport()) {
+        return;
+      }
+      event.preventDefault();
+      restartPlayback();
+      return;
+    }
+
+    if (key !== ",") {
+      return;
+    }
+
+    if (!isReady()) {
+      return;
+    }
+
+    event.preventDefault();
+    handlePlayPause();
   };
 
   const handlePointerUp = () => {
@@ -1125,11 +1221,24 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
           }
         }
         isRestoringRegions = false;
+        // Region selection is session-only. A persisted loop setting without a
+        // selected loop would misleadingly appear enabled but play from zero.
+        setLoopEnabled(false);
         syncSerializedRegions();
       });
 
-      waveSurfer.on("play", () => setIsPlaying(true));
-      waveSurfer.on("pause", () => setIsPlaying(false));
+      waveSurfer.on("play", () => {
+        setIsPlaying(true);
+        setIsPaused(false);
+      });
+      waveSurfer.on("pause", () => {
+        setIsPlaying(false);
+        setIsPaused(!transportWasStopped);
+      });
+      waveSurfer.on("finish", () => {
+        setIsPlaying(false);
+        setIsPaused(false);
+      });
       waveSurfer.on("timeupdate", (time) => setCurrentTime(time));
       waveSurfer.on("error", (error) => {
         const message = error instanceof Error ? error.message : String(error);
@@ -1185,7 +1294,11 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
       });
 
       regionsPlugin.on("region-out", (region) => {
-        if (!loopEnabled() || selectedRegionId() !== region.id || !waveSurfer) {
+        if (
+          !loopEnabled() ||
+          selectedRegionId() !== region.id ||
+          !waveSurfer?.isPlaying()
+        ) {
           return;
         }
 
@@ -1199,6 +1312,7 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
     });
 
     document.addEventListener("keydown", handleAnnotationHotkeys);
+    document.addEventListener("keydown", handleTransportHotkeys);
     document.addEventListener("pointerup", handlePointerUp);
   });
 
@@ -1208,6 +1322,7 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
     props.onPersistRequestChange?.(null);
 
     document.removeEventListener("keydown", handleAnnotationHotkeys);
+    document.removeEventListener("keydown", handleTransportHotkeys);
     document.removeEventListener("pointerup", handlePointerUp);
 
     void flushPendingPersist(false).catch(() => undefined);
@@ -1228,6 +1343,39 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
       data-testid="audio-player-panel"
     >
       <div class="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950/50">
+        <div class="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handlePlayPause}
+            disabled={!isReady()}
+            class="inline-flex min-h-11 min-w-[7rem] items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+            data-testid="audio-player-play-toggle"
+          >
+            {isPlaying() ? <Pause class="h-4 w-4" /> : <Play class="h-4 w-4" />}
+            {isPlaying() ? "Pause (,)" : "Play (,)"}
+          </button>
+          <button
+            type="button"
+            onClick={restartPlayback}
+            disabled={!isReady() || !canControlTransport()}
+            class="inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            data-testid="audio-player-restart-button"
+          >
+            <Repeat class="h-4 w-4" />
+            Restart (.)
+          </button>
+          <button
+            type="button"
+            onClick={stopAndRewind}
+            disabled={!isReady() || !canControlTransport()}
+            class="inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            data-testid="audio-player-stop-button"
+          >
+            <Square class="h-4 w-4" />
+            Stop (/)
+          </button>
+        </div>
+
         <div
           ref={waveformContainerRef}
           class="min-h-[128px] w-full"
@@ -1252,17 +1400,6 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
         </Show>
 
         <div class="flex flex-wrap items-center gap-3">
-          <button
-            type="button"
-            onClick={handlePlayPause}
-            disabled={!isReady()}
-            class="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
-            data-testid="audio-player-play-toggle"
-          >
-            {isPlaying() ? <Pause class="h-4 w-4" /> : <Play class="h-4 w-4" />}
-            {isPlaying() ? "Pause" : "Play"}
-          </button>
-
           <div class="text-sm text-slate-600 dark:text-slate-300">
             <span data-testid="audio-player-current-time">
               {formatTime(currentTime())}
@@ -1439,25 +1576,23 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
             </Show>
           </div>
 
-          <div
+          <ul
             class="min-h-0 flex-1 space-y-1 overflow-y-auto pr-1"
             onPointerDown={(event) => {
               if (event.target === event.currentTarget) {
                 clearSelection(true);
               }
             }}
-            role="listbox"
             aria-label="Saved marks and regions"
-            aria-multiselectable="true"
             data-testid="audio-player-region-list"
           >
             <Show
               when={regions().length > 0}
               fallback={
-                <p class="text-sm text-slate-500 dark:text-slate-400">
+                <li class="text-sm text-slate-500 dark:text-slate-400">
                   Add loop regions, section marks, or beat and measure marks to
                   save them with this audio reference.
-                </p>
+                </li>
               }
             >
               <For each={regions()}>
@@ -1465,23 +1600,16 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
                   (() => {
                     const kind = getAudioRegionKind(region);
                     return (
-                      <div
-                        onPointerDown={(event) =>
-                          handleRegionListPointerDown(region.id, event)
-                        }
-                        onClick={(event) =>
-                          handleRegionListClick(region.id, event)
-                        }
-                        onKeyDown={(event) =>
-                          handleRegionListKeyDown(region.id, event)
-                        }
+                      <li
                         onPointerEnter={() =>
                           handleRegionListPointerEnter(region.id)
                         }
                         class="grid w-full grid-cols-[minmax(0,1fr)_6.5rem_auto] items-center gap-2 rounded-lg border px-2 py-1 text-left transition-colors"
-                        role="option"
-                        tabIndex={0}
-                        aria-selected={selectedRegionIds().includes(region.id)}
+                        data-selected={
+                          selectedRegionIds().includes(region.id)
+                            ? "true"
+                            : "false"
+                        }
                         classList={{
                           "border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/40":
                             selectedRegionIds().includes(region.id),
@@ -1492,7 +1620,21 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
                         }}
                         data-testid={`audio-player-region-${region.id}`}
                       >
-                        <div class="min-w-0 overflow-hidden text-left text-[13px] font-medium text-slate-900 dark:text-slate-100">
+                        <button
+                          type="button"
+                          onPointerDown={(event) =>
+                            handleRegionListPointerDown(region.id, event)
+                          }
+                          onClick={(event) =>
+                            handleRegionListClick(region.id, event)
+                          }
+                          class="min-w-0 overflow-hidden text-left text-[13px] font-medium text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-slate-100"
+                        >
+                          <span class="sr-only">
+                            {selectedRegionIds().includes(region.id)
+                              ? "Selected: "
+                              : "Not selected: "}
+                          </span>
                           <span class="truncate">
                             {getRegionDisplayLabel(region)}
                           </span>
@@ -1510,7 +1652,7 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
                               </span>
                             </Show>
                           </span>
-                        </div>
+                        </button>
 
                         <Show
                           when={!isRangeAnnotation(kind)}
@@ -1571,13 +1713,13 @@ const WaveformAudioPlayer: Component<WaveformAudioPlayerProps> = (props) => {
                             <Trash2 class="h-3.5 w-3.5" />
                           </button>
                         </div>
-                      </div>
+                      </li>
                     );
                   })()
                 }
               </For>
             </Show>
-          </div>
+          </ul>
         </div>
       </div>
     </div>

--- a/src/components/rhythm/RhythmPlayer.test.tsx
+++ b/src/components/rhythm/RhythmPlayer.test.tsx
@@ -2471,7 +2471,7 @@ describe("RhythmPlayer", () => {
     });
   });
 
-  it("uses stop on the main button while playback is active", async () => {
+  it("uses pause on the main button while playback is active", async () => {
     const seedAbc = [
       "X:1",
       "T:Seed Pattern",
@@ -2518,15 +2518,121 @@ describe("RhythmPlayer", () => {
     await waitFor(() => {
       expect(
         view.getByTestId("rhythm-player-play-toggle").textContent
-      ).toContain("Stop");
+      ).toContain("Pause");
     });
 
     fireEvent.click(view.getByTestId("rhythm-player-play-toggle"));
 
-    expect(mocked.serviceStub.stop).toHaveBeenCalledTimes(1);
+    expect(mocked.serviceStub.pause).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps restart disabled until playback has been paused", async () => {
+  it("supports pedal-compatible transport shortcuts", async () => {
+    const seedAbc = [
+      "X:1",
+      "T:Seed Pattern",
+      "M:4/4",
+      "L:1/8",
+      "K:clef=perc",
+      "| A2 | A2 |",
+    ].join("\n");
+    const metadata = {
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: seedAbc,
+      rhythmSignature: "4/4",
+      patternType: "seed" as const,
+      tempoQpm: 120,
+      swingPercentage: 0,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns" as const,
+    };
+    mocked.loadPatternMock.mockResolvedValue(metadata);
+    mocked.serviceStub.metadata = () => metadata;
+
+    const view = render(() => <RhythmPlayer tuneTypeName="Reel" />);
+
+    await waitFor(() => {
+      expect(view.getByTestId("rhythm-player-play-toggle")).toBeTruthy();
+    });
+
+    fireEvent.keyDown(view.getByTestId("rhythm-player-count-in-toggle"), {
+      code: "Comma",
+      key: ",",
+    });
+    expect(mocked.serviceStub.play).toHaveBeenCalledTimes(1);
+
+    // The service exposes Solid accessors in production. Re-render with the
+    // playing accessor so the shortcut handler observes the same reactive
+    // transport state before testing restart and stop.
+    cleanup();
+    mocked.serviceStub.isPlaying = () => true;
+
+    const playingView = render(() => <RhythmPlayer tuneTypeName="Reel" />);
+    await waitFor(() => {
+      expect(
+        playingView.getByTestId("rhythm-player-play-toggle").textContent
+      ).toContain("Pause");
+    });
+
+    fireEvent.keyDown(document.body, {
+      code: "Period",
+      key: ".",
+    });
+    expect(mocked.serviceStub.stop).toHaveBeenCalledTimes(1);
+    expect(mocked.serviceStub.play).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(document.body, { key: "/", code: "Slash" });
+    expect(mocked.serviceStub.stop).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets users disable the one-bar count-in", async () => {
+    const metadata = mocked.buildEditableRhythmPattern;
+    mocked.loadPatternMock.mockResolvedValue({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: metadata().abcString,
+      rhythmSignature: "4/4",
+      patternType: "seed",
+      tempoQpm: 120,
+      swingPercentage: 0,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns",
+    });
+    mocked.serviceStub.metadata = () => ({
+      genreName: "Irish Traditional",
+      tuneTypeName: "Reel",
+      rhythmAbc: metadata().abcString,
+      rhythmSignature: "4/4",
+      patternType: "seed",
+      tempoQpm: 120,
+      swingPercentage: 0,
+      sampleKit: "bodhran",
+      premiumAudioUrl: null,
+      premiumAudioTrimMs: 0,
+      premiumAudioSource: null,
+      premiumAudioSourceTempoQpm: null,
+      source: "rhythm_patterns",
+    });
+
+    const view = render(() => <RhythmPlayer tuneTypeName="Reel" />);
+    const toggle = await view.findByTestId("rhythm-player-count-in-toggle");
+    fireEvent.click(toggle);
+    fireEvent.click(view.getByTestId("rhythm-player-play-toggle"));
+
+    expect(mocked.serviceStub.play).toHaveBeenCalledWith(
+      expect.objectContaining({ useCountIn: false })
+    );
+  });
+
+  it("enables restart only while playback is active or paused", async () => {
     const seedAbc = [
       "X:1",
       "T:Seed Pattern",
@@ -2593,7 +2699,7 @@ describe("RhythmPlayer", () => {
     });
   });
 
-  it("resets the paused position without starting playback when restart is pressed", async () => {
+  it("restarts playback from the selected section", async () => {
     const seedAbc = [
       "X:1",
       "T:Seed Pattern",
@@ -2652,7 +2758,8 @@ describe("RhythmPlayer", () => {
     });
     fireEvent.click(restartButton);
 
-    expect(mocked.serviceStub.restart).toHaveBeenCalledWith({
+    expect(mocked.serviceStub.stop).toHaveBeenCalledTimes(1);
+    expect(mocked.serviceStub.play).toHaveBeenCalledWith({
       startPositionMs: 0,
       startBeatIndex: 3,
       startMeasure: 3,
@@ -2665,10 +2772,9 @@ describe("RhythmPlayer", () => {
         "| B2 | A2 | A2 | B2 |",
       ].join("\n"),
     });
-    expect(mocked.serviceStub.play).not.toHaveBeenCalled();
   });
 
-  it("pauses and resumes independently of the main play button", async () => {
+  it("pauses and resumes from the main play button", async () => {
     const seedAbc = [
       "X:1",
       "T:Seed Pattern",
@@ -2711,7 +2817,7 @@ describe("RhythmPlayer", () => {
     mocked.serviceStub.isPlaying = () => true;
 
     const playingView = render(() => <RhythmPlayer tuneTypeName="Reel" />);
-    const pauseButton = playingView.getByTestId("rhythm-player-pause-button");
+    const pauseButton = playingView.getByTestId("rhythm-player-play-toggle");
 
     await waitFor(() => {
       expect(pauseButton.textContent).toContain("Pause");
@@ -2726,10 +2832,10 @@ describe("RhythmPlayer", () => {
     mocked.serviceStub.isPaused = () => true;
 
     const pausedView = render(() => <RhythmPlayer tuneTypeName="Reel" />);
-    const resumeButton = pausedView.getByTestId("rhythm-player-pause-button");
+    const resumeButton = pausedView.getByTestId("rhythm-player-play-toggle");
 
     await waitFor(() => {
-      expect(resumeButton.textContent).toContain("Resume");
+      expect(resumeButton.textContent).toContain("Play");
       expect(resumeButton.hasAttribute("disabled")).toBe(false);
     });
 

--- a/src/components/rhythm/RhythmPlayer.tsx
+++ b/src/components/rhythm/RhythmPlayer.tsx
@@ -20,6 +20,7 @@ import {
   createSignal,
   For,
   onCleanup,
+  onMount,
   Show,
 } from "solid-js";
 import { toast } from "solid-sonner";
@@ -237,6 +238,7 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
   const [loadedPattern, setLoadedPattern] =
     createSignal<RhythmPatternMetadata | null>(null);
   const [usePremiumLoop, setUsePremiumLoop] = createSignal(false);
+  const [isCountInEnabled, setIsCountInEnabled] = createSignal(true);
   const [selectedPatternId, setSelectedPatternId] = createSignal<string | null>(
     null
   );
@@ -453,14 +455,6 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     const tuneTypeName = props.tuneTypeName?.trim();
     return tuneTypeName ? `Rhythm Player: ${tuneTypeName}` : "Rhythm Player";
   });
-  const playToggleLabel = createMemo(() => {
-    if (isPatternLoading()) {
-      return "Loading";
-    }
-
-    return isPlaying() ? "Stop" : "Play";
-  });
-
   const closeCustomPatternEditor = () => {
     setIsCustomPatternEditorOpen(false);
     setIsDeleteCustomPatternDialogOpen(false);
@@ -729,6 +723,120 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     }
   };
 
+  const getPlaybackStartOptions = () => {
+    const usePremiumStartOffset =
+      Boolean(activePatternMetadata()?.premiumAudioUrl) && usePremiumLoop();
+
+    return {
+      startPositionMs: usePremiumStartOffset ? selectedStartPositionMs() : 0,
+      startBeatIndex: playbackPlan()?.startBeatIndex ?? 0,
+      startMeasure: playbackPlan()?.startMeasure ?? 0,
+      playbackRhythmAbc: usePremiumStartOffset
+        ? undefined
+        : (playbackAbc() ?? undefined),
+      ...(isCountInEnabled() ? {} : { useCountIn: false }),
+    };
+  };
+
+  const startPlayback = () => {
+    void service()?.play(getPlaybackStartOptions());
+  };
+
+  const playWithRestart = () => {
+    const currentService = service();
+    if (!currentService) {
+      return;
+    }
+
+    currentService.stop();
+    void currentService.play(getPlaybackStartOptions());
+  };
+
+  const shouldIgnoreTransportHotkeys = (target: EventTarget | null) => {
+    if (!(target instanceof HTMLElement)) {
+      return false;
+    }
+
+    const editableTarget = target.closest<HTMLElement>(
+      "input, textarea, [contenteditable='true']"
+    );
+    if (!editableTarget || editableTarget.isContentEditable) {
+      return Boolean(editableTarget?.isContentEditable);
+    }
+
+    if (editableTarget instanceof HTMLTextAreaElement) {
+      return true;
+    }
+
+    if (!(editableTarget instanceof HTMLInputElement)) {
+      return false;
+    }
+
+    return ![
+      "button",
+      "checkbox",
+      "color",
+      "file",
+      "hidden",
+      "radio",
+      "range",
+      "reset",
+      "submit",
+    ].includes(editableTarget.type);
+  };
+
+  const handleTransportHotkeys = (event: KeyboardEvent) => {
+    if (
+      event.defaultPrevented ||
+      event.repeat ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.altKey ||
+      shouldIgnoreTransportHotkeys(event.target) ||
+      !service() ||
+      !activePatternMetadata() ||
+      isPatternLoading()
+    ) {
+      return;
+    }
+
+    const key = event.key.toLowerCase();
+    if (key === "/") {
+      if (!isPlaying() && !isPaused()) {
+        return;
+      }
+      event.preventDefault();
+      service()?.stop();
+      return;
+    }
+
+    if (key === ".") {
+      if (!isPlaying() && !isPaused()) {
+        return;
+      }
+      event.preventDefault();
+      playWithRestart();
+      return;
+    }
+
+    if (key !== ",") {
+      return;
+    }
+
+    event.preventDefault();
+    if (isPlaying()) {
+      service()?.pause();
+      return;
+    }
+
+    if (isPaused()) {
+      void service()?.resume();
+      return;
+    }
+
+    startPlayback();
+  };
+
   const handlePatternSelectionChange = (value: string) => {
     const nextPatternId = value.trim() || null;
 
@@ -943,6 +1051,22 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
     );
   };
 
+  const countInControls = () => (
+    <label class="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300">
+      <span class="font-medium text-slate-900 dark:text-slate-100">
+        One-bar count-in
+      </span>
+      <input
+        type="checkbox"
+        checked={isCountInEnabled()}
+        disabled={!service() || !activePatternMetadata() || isPatternLoading()}
+        onChange={(event) => setIsCountInEnabled(event.currentTarget.checked)}
+        class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+        data-testid="rhythm-player-count-in-toggle"
+      />
+    </label>
+  );
+
   const getNotationContainer = (): HTMLDivElement | null => {
     const host = notationHostRef();
     if (!host) {
@@ -1122,6 +1246,11 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
 
   onCleanup(() => {
     clearActiveBeatTargets();
+    document.removeEventListener("keydown", handleTransportHotkeys);
+  });
+
+  onMount(() => {
+    document.addEventListener("keydown", handleTransportHotkeys);
   });
 
   return (
@@ -1209,6 +1338,10 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                         <div class="h-px bg-slate-200 dark:bg-slate-800" />
 
                         {metronomeControls()}
+
+                        <div class="h-px bg-slate-200 dark:bg-slate-800" />
+
+                        {countInControls()}
                       </div>
                     </DropdownMenu.Content>
                   </DropdownMenu.Portal>
@@ -1265,24 +1398,16 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                   }
 
                   if (isPlaying()) {
-                    currentService.stop();
+                    currentService.pause();
                     return;
                   }
 
-                  const usePremiumStartOffset =
-                    Boolean(activePatternMetadata()?.premiumAudioUrl) &&
-                    usePremiumLoop();
+                  if (isPaused()) {
+                    void currentService.resume();
+                    return;
+                  }
 
-                  void currentService.play({
-                    startPositionMs: usePremiumStartOffset
-                      ? selectedStartPositionMs()
-                      : 0,
-                    startBeatIndex: playbackPlan()?.startBeatIndex ?? 0,
-                    startMeasure: playbackPlan()?.startMeasure ?? 0,
-                    playbackRhythmAbc: usePremiumStartOffset
-                      ? undefined
-                      : (playbackAbc() ?? undefined),
-                  });
+                  startPlayback();
                 }}
                 disabled={
                   !service() || !activePatternMetadata() || isPatternLoading()
@@ -1295,31 +1420,17 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                   fallback={<LoaderCircle class="h-4 w-4 animate-spin" />}
                 >
                   {isPlaying() ? (
-                    <Square class="h-4 w-4" />
+                    <Pause class="h-4 w-4" />
                   ) : (
                     <Play class="h-4 w-4" />
                   )}
                 </Show>
-                {playToggleLabel()}
+                {isPlaying() ? "Pause (,)" : "Play (,)"}
               </button>
 
               <button
                 type="button"
-                onClick={() => {
-                  const currentService = service();
-                  if (!currentService) {
-                    return;
-                  }
-
-                  if (isPlaying()) {
-                    currentService.pause();
-                    return;
-                  }
-
-                  if (isPaused()) {
-                    void currentService.resume();
-                  }
-                }}
+                onClick={playWithRestart}
                 disabled={
                   !service() ||
                   !activePatternMetadata() ||
@@ -1327,53 +1438,34 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                   (!isPlaying() && !isPaused())
                 }
                 class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800 md:h-auto md:w-auto md:min-w-[7rem] md:gap-2 md:px-4 md:py-2"
-                data-testid="rhythm-player-pause-button"
-                aria-label={isPlaying() ? "Pause" : "Resume"}
-                title={isPlaying() ? "Pause" : "Resume"}
+                data-testid="rhythm-player-restart-button"
+                aria-label="Restart (.)"
+                title="Restart (.)"
               >
-                <Pause class="h-4 w-4" />
-                <span class="sr-only">{isPlaying() ? "Pause" : "Resume"}</span>
-                <span class="hidden md:inline">
-                  {isPlaying() ? "Pause" : "Resume"}
-                </span>
+                <RotateCcw class="h-4 w-4" />
+                <span class="sr-only">Restart (.)</span>
+                <span class="text-xs font-semibold md:hidden">.</span>
+                <span class="hidden md:inline">Restart (.)</span>
               </button>
 
               <button
                 type="button"
-                onClick={() => {
-                  const currentService = service();
-                  if (currentService) {
-                    const usePremiumStartOffset =
-                      Boolean(activePatternMetadata()?.premiumAudioUrl) &&
-                      usePremiumLoop();
-
-                    void currentService.restart({
-                      startPositionMs: usePremiumStartOffset
-                        ? selectedStartPositionMs()
-                        : 0,
-                      startBeatIndex: playbackPlan()?.startBeatIndex ?? 0,
-                      startMeasure: playbackPlan()?.startMeasure ?? 0,
-                      playbackRhythmAbc: usePremiumStartOffset
-                        ? undefined
-                        : (playbackAbc() ?? undefined),
-                    });
-                  }
-                }}
+                onClick={() => service()?.stop()}
                 disabled={
                   !service() ||
                   !activePatternMetadata() ||
                   isPatternLoading() ||
-                  isPlaying() ||
-                  !isPaused()
+                  (!isPlaying() && !isPaused())
                 }
                 class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-300 text-slate-700 transition-colors hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800 md:h-auto md:w-auto md:min-w-[7rem] md:gap-2 md:px-4 md:py-2"
-                data-testid="rhythm-player-restart-button"
-                aria-label="Restart"
-                title="Restart"
+                data-testid="rhythm-player-stop-button"
+                aria-label="Stop (/)"
+                title="Stop (/)"
               >
-                <RotateCcw class="h-4 w-4" />
-                <span class="sr-only">Restart</span>
-                <span class="hidden md:inline">Restart</span>
+                <Square class="h-4 w-4" />
+                <span class="sr-only">Stop (/)</span>
+                <span class="text-xs font-semibold md:hidden">/</span>
+                <span class="hidden md:inline">Stop (/)</span>
               </button>
 
               <Show when={!isMobile()}>
@@ -1383,6 +1475,8 @@ export const RhythmPlayer: Component<RhythmPlayerProps> = (props) => {
                   {swingControls()}
 
                   {metronomeControls()}
+
+                  {countInControls()}
                 </div>
               </Show>
             </div>

--- a/src/lib/services/rhythm-service/RhythmService.test.ts
+++ b/src/lib/services/rhythm-service/RhythmService.test.ts
@@ -1362,7 +1362,10 @@ describe("createRhythmService", () => {
 
       start(position?: number, units?: string) {
         this.startedWith.push({ position, units });
-        this.currentPositionMs = (position ?? 0) * 1000;
+        if (position !== undefined) {
+          this.currentPositionMs = position * 1000;
+        }
+        this.paused = false;
         this.options.beatCallback?.(1);
         this.options.eventCallback?.({
           type: "event",
@@ -1454,16 +1457,17 @@ describe("createRhythmService", () => {
 
     await service.resume();
 
-    expect(FakeTimingCallbacks.instances).toHaveLength(3);
-    expect(FakeTimingCallbacks.instances[2]?.startedWith[0]).toMatchObject({
-      position: 1.5,
-      units: "seconds",
-    });
+    expect(FakeTimingCallbacks.instances).toHaveLength(2);
+    expect(FakeTimingCallbacks.instances[1]?.startedWith).toEqual([
+      { position: 1.5, units: "seconds" },
+      { position: undefined, units: undefined },
+    ]);
+    expect(FakeTimingCallbacks.instances[1]?.currentPositionMs).toBe(1500);
 
     await service.play();
 
-    expect(FakeTimingCallbacks.instances).toHaveLength(4);
-    expect(FakeTimingCallbacks.instances[3]?.startedWith[0]).toMatchObject({
+    expect(FakeTimingCallbacks.instances).toHaveLength(3);
+    expect(FakeTimingCallbacks.instances[2]?.startedWith[0]).toMatchObject({
       position: undefined,
       units: "seconds",
     });

--- a/src/lib/services/rhythm-service/RhythmService.ts
+++ b/src/lib/services/rhythm-service/RhythmService.ts
@@ -110,6 +110,7 @@ export interface PlaybackStartOptions {
   startBeatIndex?: number;
   startMeasure?: number;
   playbackRhythmAbc?: string;
+  useCountIn?: boolean;
 }
 
 export interface RhythmService {
@@ -879,7 +880,8 @@ export function createRhythmService(
     armDebugPlaybackPasses();
     const startPositionMs = Math.max(0, startOptions?.startPositionMs ?? 0);
     lastKnownPositionMs = startPositionMs;
-    const shouldCountIn = (options.initialCountInMeasures ?? 0) > 0;
+    const shouldCountIn =
+      startOptions?.useCountIn ?? (options.initialCountInMeasures ?? 0) > 0;
     await beginPlayback(
       startPositionMs || undefined,
       shouldCountIn,
@@ -913,17 +915,28 @@ export function createRhythmService(
 
   async function resume(): Promise<void> {
     setError(null);
-    armDebugPlaybackPasses();
-    if (lastKnownPositionMs <= 0) {
+    if (!timingCallbacks || !isPaused()) {
       await play();
       return;
     }
 
-    await beginPlayback(lastKnownPositionMs, false, {
-      startBeatIndex: playbackStartBeatIndex,
-      startMeasure: playbackStartMeasure,
-      playbackRhythmAbc: activePlaybackRhythmAbc ?? undefined,
-    });
+    claimGlobalPlayback();
+
+    const audioContext = await ensureAudioContext();
+    if (audioContext.state === "suspended") {
+      await audioContext.resume();
+    }
+
+    // TimingCallbacks retains its own paused percentage and event cursor.
+    // Rebuilding it from a millisecond offset restarts its note sequence at
+    // the beginning, even though the visual timing position is preserved.
+    timingCallbacks.start();
+    if (premiumLoopAudio) {
+      await premiumLoopAudio.play();
+    }
+
+    setIsPaused(false);
+    setIsPlaying(true);
   }
 
   async function togglePlayback(): Promise<void> {

--- a/tests/components/audio/waveform-audio-player.test.tsx
+++ b/tests/components/audio/waveform-audio-player.test.tsx
@@ -516,6 +516,38 @@ describe("WaveformAudioPlayer persistence", () => {
     expect(loopToggle.checked).toBe(true);
   });
 
+  it("resumes a paused loop and stops it without restarting", async () => {
+    render(() => (
+      <WaveformAudioPlayer
+        track={{
+          referenceId: "ref-loop-transport",
+          referenceTitle: "Loop Transport",
+          url: "http://localhost:8787/api/media/view?key=users%2Fabc%2Faudio%2Floop-transport.mp3",
+        }}
+      />
+    ));
+
+    await emitReadyAfterInit();
+    fireEvent.click(screen.getByTestId("audio-player-add-region-button"));
+    fireEvent.click(screen.getByTestId("audio-player-loop-toggle"));
+    fireEvent.click(screen.getByTestId("audio-player-play-toggle"));
+
+    expect(waveSurferInstance.play).toHaveBeenCalledWith(0, 4);
+
+    waveSurferInstance.isPlaying.mockReturnValue(true);
+    fireEvent.click(screen.getByTestId("audio-player-play-toggle"));
+    emitWaveEvent("pause");
+
+    waveSurferInstance.isPlaying.mockReturnValue(false);
+    fireEvent.click(screen.getByTestId("audio-player-play-toggle"));
+    expect(waveSurferInstance.play).toHaveBeenLastCalledWith();
+    emitWaveEvent("play");
+
+    fireEvent.click(screen.getByTestId("audio-player-stop-button"));
+    expect(waveSurferInstance.pause).toHaveBeenCalled();
+    expect(waveSurferInstance.setTime).toHaveBeenLastCalledWith(0);
+  });
+
   it("restores saved settings and annotations from persisted state", async () => {
     render(() => (
       <WaveformAudioPlayer
@@ -559,6 +591,10 @@ describe("WaveformAudioPlayer persistence", () => {
       (screen.getByTestId("audio-player-loop-toggle") as HTMLInputElement)
         .disabled
     ).toBe(true);
+    expect(
+      (screen.getByTestId("audio-player-loop-toggle") as HTMLInputElement)
+        .checked
+    ).toBe(false);
     expect(screen.getByText("Beat 1")).toBeDefined();
   });
 
@@ -599,9 +635,7 @@ describe("WaveformAudioPlayer persistence", () => {
     await emitReadyAfterInit();
 
     const renderedIds = Array.from(
-      screen
-        .getByTestId("audio-player-region-list")
-        .querySelectorAll('[role="option"]')
+      screen.getByTestId("audio-player-region-list").querySelectorAll("li")
     ).map((row) => (row as HTMLElement).dataset.testid);
 
     expect(renderedIds).toEqual([
@@ -865,7 +899,7 @@ describe("WaveformAudioPlayer persistence", () => {
     expect(
       screen
         .getByTestId("audio-player-region-beat-1")
-        .getAttribute("aria-selected")
+        .getAttribute("data-selected")
     ).toBe("true");
 
     fireEvent.click(screen.getByTestId("audio-player-clear-selection-button"));
@@ -873,14 +907,14 @@ describe("WaveformAudioPlayer persistence", () => {
     expect(
       screen
         .getByTestId("audio-player-region-beat-1")
-        .getAttribute("aria-selected")
+        .getAttribute("data-selected")
     ).toBe("false");
     expect(
       screen.queryByTestId("audio-player-clear-selection-button")
     ).toBeNull();
   });
 
-  it("adds beat, measure, and section marks from keyboard shortcuts", async () => {
+  it("adds beat and measure marks from keyboard shortcuts", async () => {
     const view = render(() => (
       <WaveformAudioPlayer
         track={{
@@ -907,11 +941,6 @@ describe("WaveformAudioPlayer persistence", () => {
       code: "KeyM",
       bubbles: true,
     });
-    fireEvent.keyDown(document.body, {
-      key: "s",
-      code: "KeyS",
-      bubbles: true,
-    });
 
     view.unmount();
 
@@ -932,7 +961,40 @@ describe("WaveformAudioPlayer persistence", () => {
     expect(storedState.regions).toMatchObject([
       { kind: "beat", label: "Beat 1", end: null },
       { kind: "measure", label: "Measure 1", end: null },
-      { kind: "section", label: "Section 1", end: null },
     ]);
+  });
+
+  it("supports pedal-compatible transport shortcuts", async () => {
+    render(() => (
+      <WaveformAudioPlayer
+        track={{
+          referenceId: "ref-transport",
+          referenceTitle: "Transport Audio",
+          url: "http://localhost:8787/api/media/view?key=users%2Fabc%2Faudio%2Ftransport.mp3",
+        }}
+      />
+    ));
+
+    await emitReadyAfterInit();
+
+    fireEvent.keyDown(screen.getByTestId("audio-player-tempo-slider"), {
+      code: "Comma",
+      key: ",",
+    });
+    expect(waveSurferInstance.play).toHaveBeenCalledTimes(1);
+    emitWaveEvent("play");
+
+    fireEvent.keyDown(document.body, {
+      code: "Period",
+      key: ".",
+    });
+    expect(waveSurferInstance.pause).toHaveBeenCalledTimes(1);
+    expect(waveSurferInstance.setTime).toHaveBeenCalledWith(0);
+    expect(waveSurferInstance.play).toHaveBeenCalledTimes(2);
+    emitWaveEvent("play");
+
+    fireEvent.keyDown(document.body, { key: "/", code: "Slash" });
+    expect(waveSurferInstance.pause).toHaveBeenCalledTimes(2);
+    expect(waveSurferInstance.setTime).toHaveBeenLastCalledWith(0);
   });
 });


### PR DESCRIPTION
- standardize Audio and Rhythm transport controls around Play/Pause, Restart, and Stop
- add panel-wide pedal shortcuts: comma to play/pause, period to restart, and slash to stop/rewind; show shortcuts in button labels
- preserve loop-region pause/resume semantics and clear stale persisted loop state when no region is selected
- add optional one-bar Rhythm count-in control and playback support
- document the player transport contract and expand regression coverage
- serve real 404s for missing Pages assets and add public-hostname asset MIME/status verification to staging and production deployments
- use custom staging/production hostnames in deployment configuration

## Summary

This PR fixes #634 and #636 .

## Validation

- `npm run lint && npm run check && npm run typecheck && npm run test:unit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared keyboard and pedal shortcuts for play/pause, restart, and stop-and-rewind.
  * Added an optional one-bar count-in setting to the Rhythm Player.
  * Improved pause, resume, restart, and loop playback behavior.
  * Added a user-friendly “Page not found” page and clearer route handling.

* **Bug Fixes**
  * Improved accessibility and keyboard navigation for saved audio regions.
  * Added deployment checks to verify published assets load correctly.

* **Documentation**
  * Documented player transport controls and updated deployment validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->